### PR TITLE
Regrid on domains with different extent

### DIFF
--- a/src/regridder.jl
+++ b/src/regridder.jl
@@ -95,10 +95,11 @@ function Regridder(
 
     intersections = intersection_areas(dst_polys, src_polys; kwargs...)
 
-    # The area vectors are computed by summing the regridder along the first and second dimensions
-    # as the regridder is a matrix of the intersection areas between each grid cell between the two grids
-    src_areas = GeometryOps.area(src_polys) # sum along 2nd dimensions returns length of 1st = src grid
-    dst_areas = GeometryOps.area(dst_polys) # and vice versa
+    # If the two grids completely overlap, then the areas should be equivalent
+    # to the sum of the intersection areas along the second and fisrt dimensions, 
+    # for src and dst, respectively. This is not the case if the two grids do not cover the same area.
+    src_areas = GeometryOps.area(src_polys) 
+    dst_areas = GeometryOps.area(dst_polys) 
 
     return Regridder(intersections, src_areas, dst_areas)
 end

--- a/src/regridder.jl
+++ b/src/regridder.jl
@@ -97,8 +97,8 @@ function Regridder(
 
     # The area vectors are computed by summing the regridder along the first and second dimensions
     # as the regridder is a matrix of the intersection areas between each grid cell between the two grids
-    src_areas = vec(sum(intersections; dims=2))     # sum along 2nd dimensions returns length of 1st = src grid
-    dst_areas = vec(sum(intersections; dims=1))     # and vice versa
+    src_areas = GeometryOps.area(src_polys) # sum along 2nd dimensions returns length of 1st = src grid
+    dst_areas = GeometryOps.area(dst_polys) # and vice versa
 
     return Regridder(intersections, src_areas, dst_areas)
 end

--- a/src/regridder.jl
+++ b/src/regridder.jl
@@ -98,8 +98,8 @@ function Regridder(
     # If the two grids completely overlap, then the areas should be equivalent
     # to the sum of the intersection areas along the second and fisrt dimensions, 
     # for src and dst, respectively. This is not the case if the two grids do not cover the same area.
-    src_areas = GeometryOps.area(src_polys) 
-    dst_areas = GeometryOps.area(dst_polys) 
+    dst_areas = GeometryOps.area.(dst_polys) 
+    src_areas = GeometryOps.area.(src_polys) 
 
-    return Regridder(intersections, src_areas, dst_areas)
+    return Regridder(intersections, dst_areas, src_areas)
 end

--- a/test/oceananigans.jl
+++ b/test/oceananigans.jl
@@ -101,21 +101,27 @@ ConservativeRegridding.regrid!(vec(interior(src)), transpose(regridder), vec(int
 
 @test mean(dst) ≈ mean(src)
 
-# Does not pass until we figure out what to do for zero areas
-# large_domain_grid = RectilinearGrid(size=(100, 100), x=(0, 2), y=(0, 2), topology=(Periodic, Periodic, Flat))
-# small_domain_grid = RectilinearGrid(size=(200, 200), x=(0, 1), y=(0, 1), topology=(Periodic, Periodic, Flat))
+large_domain_grid = RectilinearGrid(size=(100, 100), x=(0, 2), y=(0, 2), topology=(Periodic, Periodic, Flat))
+small_domain_grid = RectilinearGrid(size=(200, 200), x=(0, 1), y=(0, 1), topology=(Periodic, Periodic, Flat))
 
-# src = CenterField(small_domain_grid)
-# dst = CenterField(large_domain_grid)
+src = CenterField(small_domain_grid)
+dst = CenterField(large_domain_grid)
 
-# src_cells = compute_cell_matrix(src)
-# dst_cells = compute_cell_matrix(dst)
+src_cells = compute_cell_matrix(src)
+dst_cells = compute_cell_matrix(dst)
 
-# set!(src, 1)
+set!(src, 1)
 
-# regridder = ConservativeRegridding.Regridder(dst_cells, src_cells)
+regridder = ConservativeRegridding.Regridder(dst_cells, src_cells)
 
-# ConservativeRegridding.regrid!(vec(interior(dst)), regridder, vec(interior(src)))
+ConservativeRegridding.regrid!(vec(interior(dst)), regridder, vec(interior(src)))
 
-# @test mean(dst) ≈ mean(src)
+# Compute the integral and make sure it is the same as the original field
+dst_int = Field(Integral(dst))
+src_int = Field(Integral(src))
+
+compute!(dst_int)
+compute!(src_int)
+
+@test dst_int[1, 1, 1] ≈ src[1, 1, 1]
 


### PR DESCRIPTION
by using the intersection areas to infer the areas of the polygons, if the two domains have different extent that does not overlap completely, some areas will be zero leading to NaNs where there is no intersection. 

This PR computes the areas directly from the polygons to avoid this issue