### PR TITLE
Storage space to regrid non-contiguous memory

### DIFF
--- a/src/regrid.jl
+++ b/src/regrid.jl
@@ -41,38 +41,10 @@ function regrid!(dst_field::DenseVector, regridder::Regridder, src_field::Abstra
 end
 
 function regrid!(dst_field::AbstractVector, regridder::Regridder, src_field::DenseVector)
-    regrid!(regridder.dst_tmp, regridder, src_field)
+    regrid!(regridder.dst_temp, regridder, src_field)
     dst_field .= regridder.dst_temp
     return dst_field
 end
-
-# Actual regridding, only on dense vectors...
-
-# The easy case, for dense vectors, the regridding operation defaults to a matrix multiplication
-(regridder::Regridder)(dst::DenseVector, src::DenseVector) = LinearAlgebra.mul!(dst, regridder.weights, src)
-
-# Generic regridding function that does not check the dimensions of the `src` and
-# `dst` arrays. For general vectors that might be discontinuous in memory, we need
-# to broadcast the value to a `DenseArray` before performing the sparse matrix multiply
-function (regridder::Regridder)(dst::AbstractVector, src::AbstractVector)
-    regridder.src_temp .= src
-    LinearAlgebra.mul!(regridder.dst_temp, regridder.weights, regridder.src_temp)
-    dst .= regridder.dst_temp
-    return dst
-end
-
-# Mixed cases
-function (regridder::Regridder)(dst::DenseVector, src::AbstractVector)
-    regridder.src_temp .= src
-    return LinearAlgebra.mul!(dst, regridder.weights, regridder.src_temp)
-end
-
-function (regridder::Regridder)(dst::AbstractVector, src::DenseVector)
-    LinearAlgebra.mul!(regridder.dst_temp, regridder.weights, src)
-    dst .= regridder.dst_temp
-    return dst
-end
-
 
 """$(TYPEDSIGNATURES)
 regrid a vector `src_field` using `regridder`. Area vector for the output grid can

--- a/src/regridder.jl
+++ b/src/regridder.jl
@@ -16,9 +16,9 @@ struct Regridder{W, A, V} <: AbstractRegridder
     src_temp :: V      # Dense vectors used as work-arrays if trying to regrid non-contiguous memory
 end
 
-function Base.show(io::IO, regridder::Regridder{W, A}) where {W, A}
+function Base.show(io::IO, regridder::Regridder{W, A, V}) where {W, A, V}
     n2, n1 = size(regridder)
-    println(io, "$n2×$n1 Regridder{$W, $A}")
+    println(io, "$n2×$n1 Regridder{$W, $A, $V}")
     Base.print_array(io, regridder.intersections)
     println(io, "\n\nSource areas: ", regridder.src_areas)
     print(io, "Dest.  areas: ", regridder.dst_areas)

--- a/test/simple.jl
+++ b/test/simple.jl
@@ -44,17 +44,29 @@ values_back_on_grid2 = A' * values_on_grid1 ./ area2
 
 # Test the Regridder struct with temporary vectors
 @testset "Regridder with temporary vectors" begin
-    regridder = ConservativeRegridding.Regridder(grid1, grid2; normalize=false)
+    # Create vertex arrays (not polygons) for the Regridder constructor
+    gridpoints = [(i, j) for i in 0:2, j in 0:2]
+    grid1_vertices = [[gridpoints[i, j], gridpoints[i, j+1], gridpoints[i+1, j+1], gridpoints[i+1, j], gridpoints[i, j]] for i in 1:size(gridpoints, 1)-1, j in 1:size(gridpoints, 2)-1] |> vec
+
+    grid2_vertices = [
+        [(0, 1), (1, 2), (2, 1), (1, 0), (0, 1)],  # diamond
+        [(0, 0), (1, 0), (0, 1), (0, 0)],          # triangle 1
+        [(0, 1), (0, 2), (1, 2), (0, 1)],          # triangle 2
+        [(1, 2), (2, 1), (2, 2), (1, 2)],          # triangle 3
+        [(2, 1), (2, 0), (1, 0), (2, 1)]           # triangle 4
+    ]
+
+    regridder = ConservativeRegridding.Regridder(grid1_vertices, grid2_vertices; normalize=false)
 
     # Test that temporary vectors are properly initialized
-    @test length(regridder.dst_temp) == length(grid1)
-    @test length(regridder.src_temp) == length(grid2)
+    @test length(regridder.dst_temp) == length(grid1_vertices)
+    @test length(regridder.src_temp) == length(grid2_vertices)
     @test all(regridder.dst_temp .== 0)
     @test all(regridder.src_temp .== 0)
 
     # Test regridding with dense vectors (should use optimized path)
     src_dense = Float64[0, 0, 5, 0, 0]
-    dst_dense = zeros(Float64, length(grid1))
+    dst_dense = zeros(Float64, length(grid1_vertices))
     ConservativeRegridding.regrid!(dst_dense, regridder, src_dense)
     @test sum(dst_dense .* regridder.dst_areas) ≈ sum(src_dense .* regridder.src_areas)
 
@@ -62,34 +74,50 @@ values_back_on_grid2 = A' * values_on_grid1 ./ area2
     # Create a view to simulate non-contiguous memory
     src_matrix = reshape(Float64[0, 0, 5, 0, 0, 1, 2, 3, 4, 5], 5, 2)
     src_view = view(src_matrix, :, 1)
-    dst_view = view(zeros(Float64, length(grid1), 2), :, 1)
+    dst_view = view(zeros(Float64, length(grid1_vertices), 2), :, 1)
 
     ConservativeRegridding.regrid!(dst_view, regridder, src_view)
     @test sum(dst_view .* regridder.dst_areas) ≈ sum(src_view .* regridder.src_areas)
 
     # Test mixed cases: dense dst, non-contiguous src
-    dst_dense2 = zeros(Float64, length(grid1))
+    dst_dense2 = zeros(Float64, length(grid1_vertices))
     ConservativeRegridding.regrid!(dst_dense2, regridder, src_view)
     @test dst_dense2 ≈ dst_view
 
     # Test mixed cases: non-contiguous dst, dense src
-    dst_view2 = view(zeros(Float64, length(grid1), 2), :, 1)
+    dst_view2 = view(zeros(Float64, length(grid1_vertices), 2), :, 1)
     ConservativeRegridding.regrid!(dst_view2, regridder, src_dense)
     @test sum(dst_view2 .* regridder.dst_areas) ≈ sum(src_dense .* regridder.src_areas)
 end
 
 # Test transpose functionality with temporary vectors
 @testset "Transposed Regridder" begin
-    regridder = ConservativeRegridding.Regridder(grid1, grid2; normalize=false)
+    # Create vertex arrays for the Regridder constructor
+    gridpoints = [(i, j) for i in 0:2, j in 0:2]
+    grid1_vertices = [[gridpoints[i, j], gridpoints[i, j+1], gridpoints[i+1, j+1], gridpoints[i+1, j], gridpoints[i, j]] for i in 1:size(gridpoints, 1)-1, j in 1:size(gridpoints, 2)-1] |> vec
+
+    grid2_vertices = [
+        [(0, 1), (1, 2), (2, 1), (1, 0), (0, 1)],  # diamond
+        [(0, 0), (1, 0), (0, 1), (0, 0)],          # triangle 1
+        [(0, 1), (0, 2), (1, 2), (0, 1)],          # triangle 2
+        [(1, 2), (2, 1), (2, 2), (1, 2)],          # triangle 3
+        [(2, 1), (2, 0), (1, 0), (2, 1)]           # triangle 4
+    ]
+
+    regridder = ConservativeRegridding.Regridder(grid1_vertices, grid2_vertices; normalize=false)
     regridder_T = transpose(regridder)
 
-    # Verify that transpose shares the same temporary arrays
+    # Verify that transpose swaps the areas
     @test regridder_T.src_areas === regridder.dst_areas
     @test regridder_T.dst_areas === regridder.src_areas
 
+    # Verify that transpose swaps the temporary vectors too
+    @test regridder_T.src_temp === regridder.dst_temp
+    @test regridder_T.dst_temp === regridder.src_temp
+
     # Test regridding in reverse direction
     src_on_grid1 = Float64[1, 2, 3, 4]
-    dst_on_grid2 = zeros(Float64, length(grid2))
+    dst_on_grid2 = zeros(Float64, length(grid2_vertices))
     ConservativeRegridding.regrid!(dst_on_grid2, regridder_T, src_on_grid1)
     @test sum(dst_on_grid2 .* regridder_T.dst_areas) ≈ sum(src_on_grid1 .* regridder_T.src_areas)
 end


### PR DESCRIPTION
if we try to use the regridder to regrid non contiguous data, the matrix multiply uses methods for full matrices rather than sparse matrices. 
To reproduce:
```julia
a = rand(210, 210)
b = rand(210, 210)

ad = Array(view(a, 1:200, 1:200))
bd = Array(view(b, 1:200, 1:200))
A = sprand(Float64, 200*200, 200*200, 0.0001)
```
then
```julia
julia> @time LinearAlgebra.mul!(vec(view(a, 1:200, 1:200)), A, vec(view(b, 1:200, 1:200)));
  7.000757 seconds (4 allocations: 320 bytes)

julia> @time LinearAlgebra.mul!(vec(ad), A, vec(bd));
  0.000567 seconds (2 allocations: 64 bytes)
```
This PR allocates a storage space in the regridder (like in XESMF.jl) to allow regridding non-contiguous memory efficiently.