### PR TITLE
qualify Regridder in OceananigansExt

### DIFF
--- a/ext/ConservativeRegriddingOceananigansExt.jl
+++ b/ext/ConservativeRegriddingOceananigansExt.jl
@@ -69,7 +69,7 @@ function Trees.treeify(
     # Define the grid, which is the base of the quadtree we will construct
     # on top of it.
     grid = Trees.CellBasedGrid(
-        manifold, 
+        manifold,
         cells_unitspherical
     )
     # We choose to build a quadtree on top of this grid.
@@ -105,12 +105,14 @@ GOCore.best_manifold(grid::Oceananigans.OrthogonalSphericalShellGrid) = GO.Spher
 GOCore.best_manifold(field::Oceananigans.Field) = GOCore.best_manifold(field.grid)
 
 # Extend the `on_architecture` method for a `Regridder` object
-on_architecture(arch, r::Regridder) = 
-    Regridder(on_architecture(arch, r.intersections),
-              on_architecture(arch, r.dst_areas),
-              on_architecture(arch, r.src_areas),
-              on_architecture(arch, r.dst_temp),
-              on_architecture(arch, r.src_temp))
+on_architecture(arch, r::ConservativeRegridding.Regridder) =
+    ConservativeRegridding.Regridder(
+        on_architecture(arch, r.intersections),
+        on_architecture(arch, r.dst_areas),
+        on_architecture(arch, r.src_areas),
+        on_architecture(arch, r.dst_temp),
+        on_architecture(arch, r.src_temp)
+    )
 
 
 # Allow to set example data on the field


### PR DESCRIPTION
without this I get this error from ClimaCoupler using ConservativeRegridding#main:
```
julia> err
PkgPrecompileError: The following 1 direct dependency failed to precompile:

ConservativeRegriddingOceananigansExt

Failed to precompile ConservativeRegriddingOceananigansExt [6d0d07ce-7094-5936-9fea-ace54ef64c34] to "/Users/jsloan/.julia/compiled/v1.11/ConservativeRegriddingOceananigansExt/jl_liInqS".
ERROR: LoadError: UndefVarError: `Regridder` not defined in `ConservativeRegriddingOceananigansExt`
```