### PR TITLE
Fix regrid! for n-dimensional arrays and mapreduce arg order

### DIFF
--- a/src/regridder/regrid.jl
+++ b/src/regridder/regrid.jl
@@ -1,14 +1,23 @@
 """$(TYPEDSIGNATURES)
 Regrid data on `src_field` onto `dst_field` conservatively (mean-preserving) using the `regridder` matrix.
-`dst_area` is the area of each grid cell in `dst_field` and is used to normalize the result,
-if not provided, will recompute this from `regridder`. `src_field` and `dst_field` can be any n-dimensional array,
-in which case the regridding of the 1st dimension is broadcast to additional dimensions.
+`dst_area` is the area of each grid cell in `dst_field` and is used to normalize the result;
+if not provided, it will be recomputed from `regridder`.
 
-Mathematics of regridding: if A are the intersection areas between the respective grids of the fields d (dst) and s (src),
-and aˢ and aᵈ are the areas of the source and destination grid cells, then ``d`` is computed via
+For n-dimensional arrays, regridding is applied along a single spatial dimension and
+broadcast over all remaining dimensions.  Use the `dims` keyword (default `1`) to select
+which dimension is the spatial (regridding) dimension — analogous to `eachslice(A; dims)`.
+
+For example, with a `(ncells, ntimes, nlevels)` array and `dims=1`, regridding operates
+along the first axis while iterating over times and levels.  With `dims=2`, it would
+operate along the second axis instead.
+
+## Mathematics
+
+If ``A`` are the intersection areas between the respective grids of the fields ``d`` (dst) and ``s`` (src),
+and ``aˢ`` and ``aᵈ`` are the areas of the source and destination grid cells, then ``d`` is computed via
 
 ```math
-d = (A s) / aˢ 
+d = (A s) / aˢ
 ```
 
 Note that by construction,
@@ -46,14 +55,30 @@ function regrid!(dst_field::AbstractVector, regridder::Regridder, src_field::Den
     return dst_field
 end
 
-# For n-dimensional arrays, iterate over slices of the first dimension
-function regrid!(dst_field::AbstractArray, regridder::Regridder, src_field::AbstractArray)
+# For n-dimensional arrays, iterate over slices along dimension `dims` (default: 1).
+# Like `eachslice`, `dims` specifies the spatial dimension that the regridder operates on;
+# all other dimensions are iterated over.
+function regrid!(dst_field::AbstractArray, regridder::Regridder, src_field::AbstractArray; dims::Int=1)
     if ndims(src_field) == 1
         return regrid!(vec(dst_field), regridder, vec(src_field))
     end
-    for I in CartesianIndices(axes(src_field)[2:end])
-        src_slice = view(src_field, :, I)
-        dst_slice = view(dst_field, :, I)
+    N = ndims(src_field)
+    @assert 1 <= dims <= N "dims=$dims is out of range for a $(N)-dimensional array"
+    # Collect axes for all dimensions except `dims`
+    other_axes = ntuple(i -> axes(src_field, i < dims ? i : i + 1), N - 1)
+    for I in CartesianIndices(other_axes)
+        # Build full index tuple: Colon() at position `dims`, indices elsewhere
+        idx = ntuple(N) do d
+            if d == dims
+                Colon()
+            elseif d < dims
+                I[d]
+            else
+                I[d - 1]
+            end
+        end
+        src_slice = view(src_field, idx...)
+        dst_slice = view(dst_field, idx...)
         regrid!(dst_slice, regridder, src_slice)
     end
     return dst_field

--- a/src/regridder/regrid.jl
+++ b/src/regridder/regrid.jl
@@ -46,6 +46,19 @@ function regrid!(dst_field::AbstractVector, regridder::Regridder, src_field::Den
     return dst_field
 end
 
+# For n-dimensional arrays, iterate over slices of the first dimension
+function regrid!(dst_field::AbstractArray, regridder::Regridder, src_field::AbstractArray)
+    if ndims(src_field) == 1
+        return regrid!(vec(dst_field), regridder, vec(src_field))
+    end
+    for I in CartesianIndices(axes(src_field)[2:end])
+        src_slice = view(src_field, :, I)
+        dst_slice = view(dst_field, :, I)
+        regrid!(dst_slice, regridder, src_slice)
+    end
+    return dst_field
+end
+
 """$(TYPEDSIGNATURES)
 Regrid a vector `src_field` using `regridder`. Area vector for the output grid can
 be passed on as optional argument to prevent recalculating it from the regridder."""

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -37,3 +37,43 @@ using SparseArrays
         @test Aop == spzeros(eltype(Aop), size(Aop)...)
     end
 end
+
+import GeometryOpsCore
+
+@testset "regrid! with n-dimensional arrays" begin
+    function make_grid(nx, ny)
+        polys = Matrix{GI.Polygon}(undef, nx, ny)
+        for j in 1:ny, i in 1:nx
+            x0, x1 = (i-1)/nx, i/nx
+            y0, y1 = (j-1)/ny, j/ny
+            ring = GI.LinearRing([(x0,y0),(x1,y0),(x1,y1),(x0,y1),(x0,y0)])
+            polys[i,j] = GI.Polygon([ring])
+        end
+        polys
+    end
+
+    src = make_grid(2, 2)
+    dst = make_grid(3, 3)
+    r = ConservativeRegridding.Regridder(GeometryOpsCore.Planar(), dst, src; threaded=false)
+
+    @testset "Vector (existing behavior, no regression)" begin
+        src_vec = ones(4)
+        dst_vec = zeros(9)
+        ConservativeRegridding.regrid!(dst_vec, r, src_vec)
+        @test all(dst_vec .≈ 1.0)
+    end
+
+    @testset "Matrix" begin
+        src_mat = ones(4, 3)
+        dst_mat = zeros(9, 3)
+        ConservativeRegridding.regrid!(dst_mat, r, src_mat)
+        @test all(dst_mat .≈ 1.0)
+    end
+
+    @testset "3D array" begin
+        src_3d = ones(4, 3, 2)
+        dst_3d = zeros(9, 3, 2)
+        ConservativeRegridding.regrid!(dst_3d, r, src_3d)
+        @test all(dst_3d .≈ 1.0)
+    end
+end

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -76,4 +76,34 @@ import GeometryOpsCore
         ConservativeRegridding.regrid!(dst_3d, r, src_3d)
         @test all(dst_3d .≈ 1.0)
     end
+
+    @testset "dims keyword" begin
+        @testset "dims=1 (default)" begin
+            src_mat = ones(4, 3)
+            dst_mat = zeros(9, 3)
+            ConservativeRegridding.regrid!(dst_mat, r, src_mat; dims=1)
+            @test all(dst_mat .≈ 1.0)
+        end
+
+        @testset "dims=2 (spatial dimension last)" begin
+            src_mat = ones(3, 4)
+            dst_mat = zeros(3, 9)
+            ConservativeRegridding.regrid!(dst_mat, r, src_mat; dims=2)
+            @test all(dst_mat .≈ 1.0)
+        end
+
+        @testset "dims=2 on 3D array (spatial in the middle)" begin
+            src_3d = ones(2, 4, 3)
+            dst_3d = zeros(2, 9, 3)
+            ConservativeRegridding.regrid!(dst_3d, r, src_3d; dims=2)
+            @test all(dst_3d .≈ 1.0)
+        end
+
+        @testset "dims=3 on 3D array (spatial dimension last)" begin
+            src_3d = ones(3, 2, 4)
+            dst_3d = zeros(3, 2, 9)
+            ConservativeRegridding.regrid!(dst_3d, r, src_3d; dims=3)
+            @test all(dst_3d .≈ 1.0)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

- **Fixes #67**: Add an `AbstractArray` method to `regrid!` that iterates over slices of the first dimension, enabling Matrix and higher-dimensional array inputs as promised by the docstring. The existing `AbstractVector`/`DenseVector` methods remain unchanged and take dispatch priority for vector inputs.
- **Fixes #65**: Swap `mapreduce` argument order in `cell_range_extent` for `ExplicitPolygonGrid{<: GO.Planar}` from `mapreduce(Extents.union, GI.extent, ...)` to `mapreduce(GI.extent, Extents.union, ...)` (the mapping function should come first, the reducing function second).
- Add regression tests for vector, matrix, and 3D array regridding.

## Test plan

- [x] Existing vector regridding behavior unchanged (regression test included)
- [x] Matrix (2D) regridding works correctly with uniform field
- [x] 3D array regridding works correctly with uniform field
- [x] Full test suite passes (1242 pass, 5 pre-existing broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)