### PR TITLE
Fix swapped mapreduce arguments in cell_range_extent for Planar grids

### DIFF
--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -127,7 +127,7 @@ compute the `Extents.Extent` and return it.
 =#
 
 function cell_range_extent(q::ExplicitPolygonGrid{<: GO.Planar}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    return mapreduce(Extents.union, GI.extent, (getcell(q, i, j) for i in irange, j in jrange))
+    return mapreduce(GI.extent, Extents.union, (getcell(q, i, j) for i in irange, j in jrange))
 end
 
 function cell_range_extent(q::ExplicitPolygonGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})

--- a/test/trees/grids.jl
+++ b/test/trees/grids.jl
@@ -1,6 +1,9 @@
 using ConservativeRegridding.Trees
+using ConservativeRegridding.Trees: cell_range_extent
 using Test
 import GeoInterface as GI
+import GeometryOpsCore as GOCore
+import Extents
 
 # Helper to build a matrix of lon/lat points covering the globe
 function make_lonlat_point_matrix(nx, ny)
@@ -139,5 +142,54 @@ end
 
         @test ncells(grid, 1) == 3
         @test ncells(grid, 2) == 5
+    end
+end
+
+# Regression test for issue #65: cell_range_extent had swapped mapreduce arguments
+# for ExplicitPolygonGrid{Planar}.
+@testset "cell_range_extent for Planar ExplicitPolygonGrid (#65)" begin
+    # Helper to build a simple planar unit-square grid
+    function make_planar_grid(nx, ny)
+        polys = Matrix{GI.Polygon}(undef, nx, ny)
+        for j in 1:ny, i in 1:nx
+            x0, x1 = (i - 1) / nx, i / nx
+            y0, y1 = (j - 1) / ny, j / ny
+            ring = GI.LinearRing([(x0, y0), (x1, y0), (x1, y1), (x0, y1), (x0, y0)])
+            polys[i, j] = GI.Polygon([ring])
+        end
+        polys
+    end
+
+    @testset "2×2 grid full range" begin
+        polys = make_planar_grid(2, 2)
+        epg = ExplicitPolygonGrid(GOCore.Planar(), polys)
+        ext = cell_range_extent(epg, 1:2, 1:2)
+        @test ext == Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0))
+    end
+
+    @testset "2×2 grid partial range" begin
+        polys = make_planar_grid(2, 2)
+        epg = ExplicitPolygonGrid(GOCore.Planar(), polys)
+        # Only the first cell (bottom-left quadrant)
+        ext = cell_range_extent(epg, 1:1, 1:1)
+        @test ext == Extents.Extent(X=(0.0, 0.5), Y=(0.0, 0.5))
+    end
+
+    @testset "4×3 grid full range" begin
+        polys = make_planar_grid(4, 3)
+        epg = ExplicitPolygonGrid(GOCore.Planar(), polys)
+        ext = cell_range_extent(epg, 1:4, 1:3)
+        @test ext == Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0))
+    end
+
+    @testset "4×3 grid subrange" begin
+        polys = make_planar_grid(4, 3)
+        epg = ExplicitPolygonGrid(GOCore.Planar(), polys)
+        # Cells (2:3, 1:2) should cover X=(0.25, 0.75), Y=(0.0, 2/3)
+        ext = cell_range_extent(epg, 2:3, 1:2)
+        @test ext.X[1] ≈ 0.25
+        @test ext.X[2] ≈ 0.75
+        @test ext.Y[1] ≈ 0.0
+        @test ext.Y[2] ≈ 2 / 3
     end
 end


### PR DESCRIPTION
## Summary
- Fixes swapped `mapreduce` arguments in `cell_range_extent` for `ExplicitPolygonGrid{Planar}`: the mapping function (`GI.extent`) and reducing operation (`Extents.union`) were in the wrong order
- Adds regression tests with planar polygon grids to verify correct extent computation

Fixes #65

## Test plan
- [x] Added 4 test cases for `cell_range_extent` with `ExplicitPolygonGrid{Planar}` covering full range, partial range, and subrange scenarios
- [x] All existing tests continue to pass (1246 passed, 5 pre-existing broken)
- [x] New tests verify correct `Extents.Extent` values for known grid geometries

🤖 Generated with [Claude Code](https://claude.com/claude-code)