### PR TITLE
Unify Tripolar grid extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,7 +41,7 @@ ConservativeRegriddingSpeedyWeatherExt = ["RingGrids", "SpeedyWeather"]
 [compat]
 ChunkSplitters = "3"
 ClimaCore = "0.14.49"
-Oceananigans = "0.104, 0.105"
+Oceananigans = "0.106"
 DocStringExtensions = "0.8, 0.9"
 Extents = "0.1"
 GeoInterface = "1"

--- a/ext/ConservativeRegriddingOceananigansExt.jl
+++ b/ext/ConservativeRegriddingOceananigansExt.jl
@@ -41,31 +41,6 @@ function compute_cell_matrix(grid::Oceananigans.Grids.AbstractGrid)
     return on_architecture(arch, cell_matrix)
 end
 
-# An FPivot Tripolar grid has a `RightFaceFolded` topology: the fold is at `Face` nodes,
-# which means there is an extra line of Face nodes at the north boundary.
-# The prognostic domain for fields `Center`ed in `y` ends at `Ny-1`.
-const FPivotTripolarGrid = Oceananigans.OrthogonalSphericalShellGrids.TripolarGrid{<:Any, <:Any, RightFaceFolded}
-
-function compute_cell_matrix(grid::FPivotTripolarGrid)
-    Nx, Ny, _ = size(grid)
-    ℓx, ℓy    = Center(), Center()
-
-    if isnothing(ℓx) || isnothing(ℓy)
-        error("cell_matrix can only be computed for fields with non-nothing horizontal location.")
-    end
-
-    arch = grid.architecture
-    FT = eltype(grid)
-
-    cell_matrix = Array{Tuple{FT, FT}}(undef, Nx+1, Ny)
-
-    # Not GPU compatible so we need to move the grid on the CPU
-    cpu_grid = on_architecture(CPU(), grid)
-    _compute_cell_matrix!(cell_matrix, Nx+1, Ny, ℓx, ℓy, cpu_grid)
-
-    return on_architecture(arch, cell_matrix)
-end
-
 flip(::Face) = Center()
 flip(::Center) = Face()
 
@@ -198,19 +173,7 @@ function Trees.treeify(
 
     return Trees.KnownFullSphereExtentWrapper(tree)
 end
-function Trees.treeify(
-    manifold::GOCore.Spherical,
-    grid::FPivotTripolarGrid
-)
-    # compute_cell_matrix for FPivotTripolarGrid returns (Nx+1, Ny) which
-    # excludes the diagnostic fold row, giving Nx*(Ny-1) cells matching
-    # the interior size of Center-Center fields in released Oceananigans.
-    cells_longlat = compute_cell_matrix(grid)
-    cells_unitspherical = GO.UnitSphereFromGeographic().(cells_longlat)
-    cbg = Trees.CellBasedGrid(manifold, cells_unitspherical)
-    tree = Trees.TopDownQuadtreeCursor(cbg)
-    return Trees.KnownFullSphereExtentWrapper(tree)
-end
+
 function Trees.treeify(
     manifold::GOCore.Spherical,
     grid::Oceananigans.Grids.AbstractGrid

--- a/ext/ConservativeRegriddingOceananigansExt.jl
+++ b/ext/ConservativeRegriddingOceananigansExt.jl
@@ -197,6 +197,7 @@ function Trees.treeify(
     # for long-lat grids that don't cover the whole sphere - TODO.
     return Trees.KnownFullSphereExtentWrapper(tree)
 end
+
 function Trees.treeify(manifold::GOCore.Planar, grid::Oceananigans.RectilinearGrid)
     # Compute the matrix of verti|ces - for an n×m grid, this is an (n+1)×(m+1) matrix of vertices.
     cells = compute_cell_matrix(grid) # from oceananigans_common.jl


### PR DESCRIPTION
after https://github.com/CliMA/Oceananigans.jl/pull/5408, the `RightFaceFolded` tripolar grid went back to having a prognostic domain all the way up to `1:Ny` (it was previously `1:Ny-1`).

Therefore, all the shenanigans for a `RightFaceFolded` tripolar grid are not required anymore. Now the difficult one is the `RightCenterFolded` which has an extra half row at `j = Ny`. The `RightFaceFolded` should be the easy one.