### PR TITLE
Tree search performance improvements and Neighbours API

### DIFF
--- a/examples/lowlevel/climacore_exp.jl
+++ b/examples/lowlevel/climacore_exp.jl
@@ -264,7 +264,19 @@ quadtrees = map(1:6, all_coords) do face_idx, coords
 end
 
 
-final_tree = Trees.CubedSphereToplevelTree(quadtrees)
+connectivity = let topology = space.grid.topology
+    table = Array{Tuple{Int8, Int8, Bool}, 2}(undef, 4, 6)
+    for F in 1:6, edge in 1:4
+        s = max(ne ÷ 2, 1)
+        i, j = edge == 1 ? (s, 1) : edge == 2 ? (ne, s) : edge == 3 ? (s, ne) : (1, s)
+        elem = i + (j - 1) * ne + (F - 1) * ne^2
+        opelem, opface, reversed = Topologies.opposing_face(topology, elem, edge)
+        F_prime = ((opelem - 1) ÷ ne^2) + 1
+        table[edge, F] = (Int8(F_prime), Int8(opface), Bool(reversed))
+    end
+    Trees.CubeFaceConnectivity(table, ne)
+end
+final_tree = Trees.CubedSphereToplevelTree(quadtrees, connectivity)
 
 latlon_grid = LatitudeLongitudeGrid(size=(360, 180, 1), longitude=(0, 360), latitude=(-90, 90), z = (0, 1), radius = mesh.domain.radius)
 

--- a/ext/ConservativeRegriddingClimaCoreExt.jl
+++ b/ext/ConservativeRegriddingClimaCoreExt.jl
@@ -35,6 +35,57 @@ function coords_for_face(mesh::Meshes.AbstractCubedSphere, face_idx)
     return coords
 end
 
+"""
+    edge_representative(edge, ne) -> (i, j)
+
+Pick a representative element on the given cube edge of a face that is
+*interior* to the edge (i.e. not at a face corner). Used by
+[`build_cube_connectivity`](@ref) so that the queried element-local face is
+unambiguously the cube-edge crossing.
+"""
+function edge_representative(edge::Integer, ne::Integer)
+    s = max(ne ÷ 2, 1)
+    if edge == 1        # south
+        return (s, 1)
+    elseif edge == 2    # east
+        return (ne, s)
+    elseif edge == 3    # north
+        return (s, ne)
+    else                # west
+        return (1, s)
+    end
+end
+
+"""
+    build_cube_connectivity(topology, ne) -> Trees.CubeFaceConnectivity
+
+Build the cube-face connectivity table used by `neighbours` on a
+`CubedSphereToplevelTree`. For each `(face F, edge edge_id)`, query
+`Topologies.opposing_face` on a representative element interior to that edge,
+and decode the result into `(neighbour_face, neighbour_edge, reversed)`.
+
+This relies on two ClimaCore conventions that hold for `Topology2D` on the
+default cubed-sphere mesh:
+
+- `topology.elemorder == CartesianIndices((ne, ne, 6))`, so the global element
+  index is `i + (j-1)*ne + (F-1)*ne²` (the same scheme used by
+  `IndexOffsetQuadtreeCursor`).
+- Element-local face IDs (1=south, 2=east, 3=north, 4=west) match our cube-edge
+  IDs.
+"""
+function build_cube_connectivity(topology, ne::Integer)
+    table = Array{Tuple{Int8, Int8, Bool}, 2}(undef, 4, 6)
+    ne2 = ne * ne
+    for F in 1:6, edge in 1:4
+        i, j = edge_representative(edge, ne)
+        elem = i + (j - 1) * ne + (F - 1) * ne2
+        opelem, opface, reversed = Topologies.opposing_face(topology, elem, edge)
+        F_prime = ((opelem - 1) ÷ ne2) + 1
+        table[edge, F] = (Int8(F_prime), Int8(opface), Bool(reversed))
+    end
+    return Trees.CubeFaceConnectivity(table, Int(ne))
+end
+
 function Trees.treeify(manifold::GOCore.Spherical, topology::Topologies.Topology2D{<: ClimaComms.AbstractCommsContext, <: Meshes.AbstractCubedSphere})
     mesh = topology.mesh
     ne = mesh.ne
@@ -85,7 +136,8 @@ function Trees.treeify(manifold::GOCore.Spherical, topology::Topologies.Topology
         error("Unknown spacefillingcurve type: $(typeof(topology.spacefillingcurve))\nExpected a CartesianIndices or a Vector{CartesianIndex{3}}")
     end
 
-    return Trees.CubedSphereToplevelTree(quadtrees)
+    connectivity = build_cube_connectivity(topology, ne)
+    return Trees.CubedSphereToplevelTree(quadtrees, connectivity)
 end
 
 Trees.treeify(manifold::GOCore.Spherical, space::ClimaCore.Spaces.AbstractSpectralElementSpace) = Trees.treeify(manifold, Spaces.topology(space))

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -31,13 +31,27 @@ function compute_intersection_areas(
     return ret_i1, ret_i2, ret_area
 end
 
+# If the root tree is a `WithParallelizePolicy`, route the dual-DFS's
+# `(node, extent)` query through the user policy; otherwise fall back to the
+# default `should_parallelize` dispatch. The wrapper is *not* a dispatch axis
+# on `should_parallelize` — detecting it here keeps the dispatch graph simple.
+@inline function _build_parallelize_closure(tree)
+    if tree isa Trees.WithParallelizePolicy
+        let inner = tree.tree, p = tree.policy
+            return (node, extent) -> p(inner, node, extent)
+        end
+    else
+        return (node, extent) -> Trees.should_parallelize(node, extent)
+    end
+end
+
 function get_all_candidate_pairs(threaded::True, predicate_f::F, src_tree::T1, dst_tree::T2) where {F, T1, T2}
     # TODO: Threaded dual dfs via chunking.
     # For now this is just serial, and is the big bottleneck for larger grids.
     # First, run the dual depth first search to get all candidate pairs of
     # cells that may intersect.
-    par_src = (node, extent) -> Trees.should_parallelize(src_tree, node, extent)
-    par_dst = (node, extent) -> Trees.should_parallelize(dst_tree, node, extent)
+    par_src = _build_parallelize_closure(src_tree)
+    par_dst = _build_parallelize_closure(dst_tree)
     candidate_idxs = multithreaded_dual_query(predicate_f, par_src, par_dst, src_tree, dst_tree) # from utils/MultithreadedDualDepthFirstSearch.jl
     return candidate_idxs
 end

--- a/src/trees/Trees.jl
+++ b/src/trees/Trees.jl
@@ -7,17 +7,20 @@ import GeometryOps as GO
 import GeometryOps: UnitSpherical as US, SpatialTreeInterface as STI
 
 include("interfaces.jl")
+include("neighbours_interface.jl")
 include("wrappers.jl")
 include("grids.jl")
 
 include("quadtree_cursors.jl")
 include("specialized_quadtree_cursors.jl")
+include("neighbours.jl")
 
-# private IndexOffsetQuadtreeCursor, CubedSphereToplevelTree
+# private IndexOffsetQuadtreeCursor, CubedSphereToplevelTree, CubeFaceConnectivity
 
 export AbstractCurvilinearGrid, ncells, getcell
 export ExplicitPolygonGrid, CellBasedGrid, RegularGrid
 export QuadtreeCursor, TopDownQuadtreeCursor
+export LonLatConnectivityWrapper
 export should_parallelize, WithParallelizePolicy
 
 end

--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -173,78 +173,133 @@ Since we know our grids are curvilinear, this is broadly okay.  It's not perfect
 =#
 
 using LinearAlgebra
+
+#=
+Spherical `cell_range_extent` machinery.
+
+The bounding-cap algorithm needs the four corners of the index rectangle plus
+points sampled along its perimeter (because cell edges follow constant-lat /
+constant-lon, not great-circles, so they bulge differently). Earlier versions
+materialized the perimeter into a fresh `Vector` per call — that drove most of
+the GC pressure in the dual-DFS hot path.
+
+Now the perimeter is a stack-resident iterator (`PerimeterPoints`) that yields
+points on demand via a small per-grid `_pt_at` method, and the cap builder
+consumes any iterator over `UnitSphericalPoint`s. No buffers, no shared state,
+threadsafe by construction.
+=#
+
+# Per-grid: materialize the UnitSphericalPoint at point-index (i, j).
+@inline _pt_at(g::RegularGrid{<: GO.Spherical}, i::Int, j::Int) =
+    GO.UnitSphereFromGeographic()((g.x[i], g.y[j]))
+@inline _pt_at(g::CellBasedGrid{<: GO.Spherical}, i::Int, j::Int) =
+    @inbounds g.points[i, j]
+
+# Perimeter iterator: walks the four sides of the [imin..imax] × [jmin..jmax]
+# index rectangle in order (west column, east column, north row, south row),
+# skipping degenerate sides. Yields the `_pt_at(grid, i, j)` for each border
+# point. State is `(side::Int, k::Int)`; `side > 4` signals exhaustion.
+struct PerimeterPoints{G}
+    grid::G
+    imin::Int
+    imax::Int
+    jmin::Int
+    jmax::Int
+end
+
+Base.IteratorSize(::Type{<: PerimeterPoints}) = Base.HasLength()
+function Base.length(p::PerimeterPoints)
+    nrow = p.imax - p.imin + 1
+    ncol = p.jmax - p.jmin + 1
+    n = ncol                                       # west column
+    n += (p.imax != p.imin) * ncol                 # east column
+    n += (p.jmax != p.jmin) * nrow * 2             # north + south rows
+    return n
+end
+Base.eltype(::Type{PerimeterPoints{G}}) where {G} =
+    Core.Compiler.return_type(_pt_at, Tuple{G, Int, Int})
+
+@inline function Base.iterate(p::PerimeterPoints, state = (1, p.jmin))
+    while true
+        side, k = state
+        if side == 1                               # west: (imin, k)
+            k <= p.jmax && return _pt_at(p.grid, p.imin, k), (1, k + 1)
+            state = (2, p.jmin)
+        elseif side == 2                           # east: (imax, k)
+            (p.imax != p.imin && k <= p.jmax) &&
+                return _pt_at(p.grid, p.imax, k), (2, k + 1)
+            state = (3, p.imin)
+        elseif side == 3                           # north: (k, jmax)
+            (p.jmax != p.jmin && k <= p.imax) &&
+                return _pt_at(p.grid, k, p.jmax), (3, k + 1)
+            state = (4, p.imin)
+        elseif side == 4                           # south: (k, jmin)
+            (p.jmax != p.jmin && k <= p.imax) &&
+                return _pt_at(p.grid, k, p.jmin), (4, k + 1)
+            return nothing
+        else
+            return nothing
+        end
+    end
+end
+
+"""
+    circle_from_four_corners(corner_points, other_points)
+
+Bounding `SphericalCap` covering 4 cell corners passed in (BL, TL, BR, TR) order
+plus an iterable of additional perimeter points. `corner_points` and the
+elements of `other_points` may be `UnitSphericalPoint`s or `(lon, lat)` tuples
+— `UnitSphereFromGeographic` is a no-op on already-converted points.
+
+Public for use by extensions (e.g. `HealpixExt`) that build trees out of
+arbitrary 4-corner polygons. Internally a thin wrapper over [`_spherical_cap`].
+"""
 function circle_from_four_corners(corner_points, other_points)
     raw = GO.UnitSphereFromGeographic().(corner_points)
-    # corner_points arrive as (BL, TL, BR, TR); reorder to CCW (BL, BR, TR, TL)
-    # so that consecutive slerps give bottom, right, top, left edge midpoints.
+    # Reorder (BL, TL, BR, TR) → CCW (SW, SE, NE, NW) for slerp midpoints.
     p1, p2, p3, p4 = raw[1], raw[3], raw[4], raw[2]
-    center = LinearAlgebra.normalize((p1 .+ p2 .+ p3 .+ p4) ./ 4)
-    # Midpoints of edges (bottom, right, top, left)
+    return _spherical_cap(p1, p2, p3, p4,
+        (GO.UnitSphereFromGeographic()(p) for p in other_points))
+end
+
+# Build a SphericalCap covering 4 CCW corners (SW, SE, NE, NW), the slerp
+# midpoints of their 4 edges (great-circle bulge), and every point yielded by
+# `perimeter` (constant-lat/lon bulge along cell sides).
+@inline function _spherical_cap(p1, p2, p3, p4, perimeter)
+    center = LinearAlgebra.normalize((p1 + p2 + p3 + p4) / 4)
     p12 = GO.UnitSpherical.slerp(p1, p2, 0.5)
     p23 = GO.UnitSpherical.slerp(p2, p3, 0.5)
     p34 = GO.UnitSpherical.slerp(p3, p4, 0.5)
     p41 = GO.UnitSpherical.slerp(p4, p1, 0.5)
-    # Distance to the furthest corner or edge midpoint
-    corner_distance = maximum(p -> GO.spherical_distance(center, p), (p1, p2, p3, p4, p12, p23, p34, p41))
-    # Distance to the furthest other point
-    other_distance = maximum(p -> GO.spherical_distance(center, p), GO.UnitSphereFromGeographic().(other_points); init = corner_distance)
-    # Distance to the furthest point
-    distance = max(corner_distance, other_distance)
-    #The `*1.0001` is done to not miss intersections through numerical inaccuracies
-    return GO.UnitSpherical.SphericalCap(center, distance*1.0001)
+    d = max(
+        GO.spherical_distance(center, p1), GO.spherical_distance(center, p2),
+        GO.spherical_distance(center, p3), GO.spherical_distance(center, p4),
+        GO.spherical_distance(center, p12), GO.spherical_distance(center, p23),
+        GO.spherical_distance(center, p34), GO.spherical_distance(center, p41),
+    )
+    for p in perimeter
+        d = max(d, GO.spherical_distance(center, p))
+    end
+    # The 1.0001 slack guards against missed intersections from rounding error.
+    return GO.UnitSpherical.SphericalCap(center, d * 1.0001)
 end
 
 function cell_range_extent(q::CellBasedGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    imin, imax = extrema(irange)
-    jmin, jmax = extrema(jrange)
-    # For cell based we need 1 to the max indices from cell space
-    # to get the max indices in point space (`(n,m) -> (n+1, m+1)`)
-    imax += 1
-    jmax += 1
-
-    quadtree_points = q.points
-    corner_points = (quadtree_points[imin, jmin], quadtree_points[imin, jmax], quadtree_points[imax, jmin], quadtree_points[imax, jmax])
-
-    # Collect points from all border rows/columns
-    other_points = typeof(GI.getpoint(GI.getexterior(getcell(q, imin, jmin)), 1))[]
-    sizehint!(other_points, 2 * (imax - imin + 1) + 2 * (jmax - jmin + 1))
-    # Left and right columns (all rows)
-    append!(other_points, view(q.points, imin, jmin:jmax))
-    if imax != imin
-        append!(other_points, view(q.points, imax, jmin:jmax))
-    end
-    # Top and bottom rows (all columns)
-    if jmax != jmin
-        append!(other_points, view(q.points, imin:imax, jmax))
-        append!(other_points, view(q.points, imin:imax, jmin))
-    end
-    return circle_from_four_corners(corner_points, other_points)
+    imin, imax = extrema(irange); imax += 1
+    jmin, jmax = extrema(jrange); jmax += 1
+    return _spherical_cap(
+        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
+        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
+        PerimeterPoints(q, imin, imax, jmin, jmax),
+    )
 end
 
 function cell_range_extent(q::RegularGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    imin, imax = extrema(irange)
-    jmin, jmax = extrema(jrange)
-    # For cell based we need 1 to the max indices from cell space 
-    # to get the max indices in point space (`(n,m) -> (n+1, m+1)`)
-    imax += 1
-    jmax += 1
-
-    corner_points = ((q.x[imin], q.y[jmin]), (q.x[imin], q.y[jmax]), (q.x[imax], q.y[jmin]), (q.x[imax], q.y[jmax]))
-
-    # Collect points from all border polygons
-    other_points = typeof(GI.getpoint(GI.getexterior(getcell(q, imin, jmin)), 1))[]
-    sizehint!(other_points, (imax - imin + 1) * (jmax - jmin + 1))
-    # Top and bottom rows (all columns)
-    append!(other_points, tuple.(q.x[imin], q.y[jmin:jmax]))
-    if imax != imin
-        append!(other_points, tuple.(q.x[imax], q.y[jmin:jmax]))
-    end
-    if jmax != jmin
-        append!(other_points, tuple.(q.x[imin:imax], q.y[jmax]))
-    end
-    # Bottom row (all columns) - needed for correct cap near poles
-    if jmin != jmax
-        append!(other_points, tuple.(q.x[imin:imax], q.y[jmin]))
-    end
-    return circle_from_four_corners(corner_points, other_points)
+    imin, imax = extrema(irange); imax += 1
+    jmin, jmax = extrema(jrange); jmax += 1
+    return _spherical_cap(
+        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
+        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
+        PerimeterPoints(q, imin, imax, jmin, jmax),
+    )
 end

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -19,65 +19,74 @@ import Extents
 import SortTileRecursiveTree # in order to implement the `getcell/ncell` interface
 
 """
-    should_parallelize(tree, node, extent) -> Bool
+    should_parallelize(node, extent) -> Bool
 
-Decide whether to spawn a parallel task at `node` of `tree` during the
-multithreaded dual-tree traversal used to find candidate intersecting
-cell pairs.
+Decide whether to spawn a parallel task at `node` during the multithreaded
+dual-tree traversal used to find candidate intersecting cell pairs.
 
 Returning `true` means *this node is the granularity at which a task is
-spawned*: the dual DFS stops descending recursively into children for
-the purpose of further parallelism and runs the subtree as a single
-parallel unit. Returning `false` means *keep descending* — the node is
-still too coarse and a task at this level would create unbalanced work.
+spawned*: the dual DFS stops descending recursively into children for the
+purpose of further parallelism and runs the subtree as a single parallel
+unit. Returning `false` means *keep descending* — the node is still too
+coarse and a task at this level would create unbalanced work.
 
 `extent` is the bounding region of `node` (e.g. an `Extents.Extent` for
 planar grids or a `SphericalCap` for spherical grids). It is passed
 explicitly so implementations and the dual DFS share one computation per
 node.
 
+Dispatch is on `(node_type, extent_type)` only — the root tree is *not*
+a dispatch axis. To express tree-aware logic (e.g. "spawn when subtree
+covers ≤ 1/N of the root grid"), wrap the root tree with
+[`WithParallelizePolicy`](@ref); the wrapper plumbs the tree into a
+local closure that the dual DFS calls without participating in dispatch.
+
 # Defaults
 
-- `extent::SphericalCap`: spawns once the cap covers less than ¼ of the
-  unit sphere — a heuristic that avoids spawning a single task at the
-  root. This works because spherical caps have a natural upper bound
-  (the full unit sphere is ~4π steradians) against which "small enough"
-  has a fixed meaning.
-- `extent::Extents.Extent`: errors. Planar extents have no canonical
-  scale — a "unit square" might be 1 metre, 1 degree, or 10⁹ metres —
-  and there is no upper or lower bound on the magnitude of an `Extent`,
-  so no manifold-agnostic default can decide "small enough" without
-  knowing the tree's own notion of size. Tree authors must supply
-  their own method.
+- `(::AbstractQuadtreeCursor, ::SphericalCap | ::Extents.Extent)`: leaf-count
+  test using `node.grid` for total cells. Spawns once the subtree covers
+  ≤ `prod(ncells(node.grid)) ÷ (Threads.nthreads() * 32)` leaves. Defined
+  in `quadtree_cursors.jl`.
+- `(::Any, ::SphericalCap)`: spawns once the cap covers less than ¼ of the
+  unit sphere — a coarse heuristic for foreign tree types where leaf count
+  isn't cheap.
+- `(::Any, ::Extents.Extent)`: errors. Planar extents have no canonical
+  scale — tree authors must supply their own method (or wrap with
+  [`WithParallelizePolicy`](@ref)).
 
 # Customization
 
-Override per tree type by adding a more-specific method:
+Two paths:
 
-```julia
-ConservativeRegridding.Trees.should_parallelize(
-    tree::MyTree, node, extent::Extents.Extent,
-) = prod(ncells(node)) ≤ prod(ncells(getgrid(tree))) ÷ (Threads.nthreads() * 4)
-```
+1. **Tree-type-specific override** — define a node-type-specific method:
 
-…or wrap any tree at construction time with [`WithParallelizePolicy`](@ref)
-to supply an instance-level callable without defining a method:
+   ```julia
+   ConservativeRegridding.Trees.should_parallelize(
+       node::MyCursorType, extent::Extents.Extent,
+   ) = prod(ncells(node)) ≤ prod(ncells(node.grid)) ÷ (Threads.nthreads() * 4)
+   ```
 
-```julia
-tree_with_policy = WithParallelizePolicy(my_tree, (node, extent) -> ...)
-```
+2. **Instance-level wrapper** — wrap the root tree at construction time:
+
+   ```julia
+   tree_with_policy = WithParallelizePolicy(my_tree, (tree, node, extent) -> ...)
+   ```
+
+   The wrapper plumbs the policy through the dual DFS via a local closure
+   in `intersection_areas.jl`, so it doesn't participate in dispatch.
 """
 function should_parallelize end
 
-should_parallelize(tree, node, extent::GO.UnitSpherical.SphericalCap) =
+should_parallelize(node, extent::GO.UnitSpherical.SphericalCap) =
     (2π * (1 - cos(extent.radius))) < π
 
-should_parallelize(tree, node, extent::Extents.Extent) = error(
+should_parallelize(node, extent::Extents.Extent) = error(
     """
-    `Trees.should_parallelize` has no method for planar `Extents.Extent` on tree of type `$(typeof(tree))`.
-    Planar trees must define a tree-type-specific method, e.g. 
-    `ConservativeRegridding.Trees.should_parallelize(::$(typeof(tree)), node, extent::Extents.Extent) = ...`
-    to control multithreading granularity.
+    `Trees.should_parallelize` has no method for planar `Extents.Extent` on node of type `$(typeof(node))`.
+    Either define a node-type-specific method:
+        `ConservativeRegridding.Trees.should_parallelize(::$(typeof(node)), extent::Extents.Extent) = ...`
+    or wrap your tree with `WithParallelizePolicy(tree, policy)` to supply an
+    instance-level callable.
     """
 )
 

--- a/src/trees/neighbours.jl
+++ b/src/trees/neighbours.jl
@@ -1,0 +1,304 @@
+#=
+# Neighbours
+
+This file provides concrete implementations of the [`neighbours`](@ref) interface
+declared in `neighbours_interface.jl`, for two grid families:
+
+- Cubed sphere (via [`CubedSphereToplevelTree`](@ref) — typically built by the
+  ClimaCore extension).
+- Longitude-latitude regular grids (via [`LonLatConnectivityWrapper`](@ref)).
+
+`findidx`, `dual_neighbours`, and `AbstractNeighbourCache` are out of scope here.
+
+The `CubeFaceConnectivity` struct lives in `wrappers.jl` so that
+`CubedSphereToplevelTree` can carry it as a field without forward-declaration
+gymnastics.
+=#
+
+import GeometryOps: SpatialTreeInterface as STI
+import GeometryOpsCore as GOCore
+import GeometryOps as GO
+
+# 8 CCW offsets, starting at south and rotating counter-clockwise:
+# S, SE, E, NE, N, NW, W, SW
+const _NEIGHBOUR_OFFSETS = (
+    (0, -1),   # S
+    (1, -1),   # SE
+    (1,  0),   # E
+    (1,  1),   # NE
+    (0,  1),   # N
+    (-1, 1),   # NW
+    (-1, 0),   # W
+    (-1,-1),   # SW
+)
+
+#=
+## LonLatConnectivityWrapper
+
+A pass-through tree wrapper that augments a regular lon/lat
+[`TopDownQuadtreeCursor`](@ref) (built on a [`RegularGrid`](@ref)) with the
+metadata needed to compute `neighbours` correctly across periodic-x and
+pole-fold boundaries.
+
+The constructor `LonLatConnectivityWrapper(tree)` infers the three
+boolean flags from the underlying grid's coordinate vectors:
+
+- `periodic_x`        : `x[end] - x[1] ≈ 360°`
+- `pole_top_fold`     : `y[end] ≈  90°` and `iseven(nlon)`
+- `pole_bottom_fold`  : `y[1]   ≈ -90°` and `iseven(nlon)`
+
+For `Planar` manifolds all three are forced false. The wrapper is invisible
+to existing dual-DFS / regridder code; only `neighbours` makes use of it.
+=#
+
+"""
+    LonLatConnectivityWrapper(tree)
+
+A pass-through wrapper around a `TopDownQuadtreeCursor` (or similar) wrapping
+a `RegularGrid` on a `Spherical()` manifold, that records whether the grid is
+periodic in longitude and whether it folds across either pole. These flags are
+used by [`neighbours`](@ref) to wrap and fold linear indices correctly at
+domain boundaries.
+
+The convenience constructor reads the grid's `x`/`y` coordinate vectors and the
+manifold to infer the flags. Tolerance for the periodicity / pole tests is
+`3.6e-4°`. For `Planar()` manifolds, all three flags are forced false. For odd
+`nlon`, both fold flags are forced false (the fold is mathematically
+ill-defined; cells at the pole row simply return fewer neighbours).
+"""
+struct LonLatConnectivityWrapper{T}
+    tree::T
+    periodic_x::Bool
+    pole_top_fold::Bool
+    pole_bottom_fold::Bool
+    nlon::Int
+    nlat::Int
+end
+
+function LonLatConnectivityWrapper(tree)
+    grid = getgrid(tree)
+    grid isa RegularGrid || throw(ArgumentError(
+        "LonLatConnectivityWrapper expects a RegularGrid; got $(typeof(grid))"
+    ))
+    x = grid.x
+    y = grid.y
+    nlon = length(x) - 1
+    nlat = length(y) - 1
+    manifold = grid.manifold
+
+    atol = 3.6e-4 # ≈ 1e-6 * 360°
+    if manifold isa GO.Planar
+        periodic_x = false
+        pole_top_fold = false
+        pole_bottom_fold = false
+    else
+        periodic_x = isapprox(x[end] - x[1], 360.0; atol)
+        # Folds only make sense when nlon is even; otherwise mod1(i + nlon÷2, nlon)
+        # does not pair distinct cells across the pole.
+        pole_top_fold = iseven(nlon) && isapprox(y[end],  90.0; atol)
+        pole_bottom_fold = iseven(nlon) && isapprox(y[1],  -90.0; atol)
+    end
+
+    return LonLatConnectivityWrapper(tree, periodic_x, pole_top_fold, pole_bottom_fold, nlon, nlat)
+end
+
+# Pass-through STI methods so the wrapper is invisible to dual-DFS / regridder.
+STI.isspatialtree(::Type{<: LonLatConnectivityWrapper}) = true
+STI.nchild(w::LonLatConnectivityWrapper) = STI.nchild(w.tree)
+STI.getchild(w::LonLatConnectivityWrapper, i::Int) = STI.getchild(w.tree, i)
+STI.isleaf(w::LonLatConnectivityWrapper) = STI.isleaf(w.tree)
+STI.node_extent(w::LonLatConnectivityWrapper) = STI.node_extent(w.tree)
+STI.child_indices_extents(w::LonLatConnectivityWrapper) = STI.child_indices_extents(w.tree)
+
+# Pass-through cell-access methods so callers (build_weights, areas, etc.)
+# can use a wrapped tree the same way as the underlying one.
+getcell(w::LonLatConnectivityWrapper) = getcell(w.tree)
+getcell(w::LonLatConnectivityWrapper, args...) = getcell(w.tree, args...)
+ncells(w::LonLatConnectivityWrapper) = ncells(w.tree)
+ncells(w::LonLatConnectivityWrapper, dim::Int) = ncells(w.tree, dim)
+cell_range_extent(w::LonLatConnectivityWrapper, args...) = cell_range_extent(w.tree, args...)
+
+getgrid(w::LonLatConnectivityWrapper) = getgrid(w.tree)
+
+#=
+## Cubed-sphere neighbours
+
+Decode the global index to `(face, i, j)`, walk the 8 CCW offsets, and resolve
+edge crossings via the connectivity table. Cube-corner cells naturally drop one
+neighbour (the diagonal pointing through the 3-face cube corner is the only
+offset that overflows in *both* axes simultaneously) — so corners return 7
+neighbours and other cells 8, with no special case in code.
+=#
+
+# Which cube edge a (i_new, j_new) overflow points to. Returns 1..4 matching
+# the same numbering used by `CubeFaceConnectivity`:
+# 1 = south (j_new < 1), 2 = east (i_new > ne),
+# 3 = north (j_new > ne), 4 = west (i_new < 1).
+@inline function _which_edge(i_new::Int, j_new::Int, ne::Int)
+    if j_new < 1
+        return 1
+    elseif i_new > ne
+        return 2
+    elseif j_new > ne
+        return 3
+    else  # i_new < 1
+        return 4
+    end
+end
+
+# Step one cell into the destination face from the given (other-face) edge,
+# at the along-edge coordinate `s` (∈ 1..ne).
+@inline function _step_in_from_edge(other_edge::Integer, s::Int, ne::Int)
+    if other_edge == 1        # south: j = 1, i = s
+        return s, 1
+    elseif other_edge == 2    # east:  i = ne, j = s
+        return ne, s
+    elseif other_edge == 3    # north: j = ne, i = s
+        return s, ne
+    else                      # west:  i = 1, j = s
+        return 1, s
+    end
+end
+
+@inline function _cube_linear(face::Integer, i::Integer, j::Integer, ne::Integer)
+    return Int(i) + (Int(j) - 1) * Int(ne) + (Int(face) - 1) * Int(ne)^2
+end
+
+"""
+    neighbours(tree::CubedSphereToplevelTree, idx::Integer) -> Vector{Int}
+
+Return the linear global indices of cells that share an edge or corner with the
+cell at `idx` on a cubed sphere. Length is 8 in the interior of a face or
+across an edge, and 7 at the eight cube corners (where three faces meet).
+
+Indices follow the same `face_local + (face-1)*ne²` scheme used by
+`IndexOffsetQuadtreeCursor`, so the returned indices match the regridder's
+sparse-matrix row/column convention.
+"""
+function neighbours(tree::CubedSphereToplevelTree, idx::Integer)
+    # TODO: replace per-call allocation with preallocated buffer when AbstractNeighbourCache lands
+    conn = tree.connectivity
+    ne = conn.ne
+    table = conn.table
+
+    ne2 = ne * ne
+    face_idx = ((Int(idx) - 1) ÷ ne2) + 1
+    face_local_idx = ((Int(idx) - 1) % ne2) + 1
+    i = mod1(face_local_idx, ne)
+    j = ((face_local_idx - 1) ÷ ne) + 1
+
+    result = Int[]
+    sizehint!(result, 8)
+
+    for (di, dj) in _NEIGHBOUR_OFFSETS
+        i_new = i + di
+        j_new = j + dj
+        in_i = 1 <= i_new <= ne
+        in_j = 1 <= j_new <= ne
+
+        if in_i && in_j
+            push!(result, _cube_linear(face_idx, i_new, j_new, ne))
+        elseif in_i ⊻ in_j
+            edge_id = _which_edge(i_new, j_new, ne)
+            other_face, other_edge, reversed = table[edge_id, face_idx]
+            # along-edge coord on the source side, ∈ 1..ne
+            s = (edge_id == 1 || edge_id == 3) ? i_new : j_new
+            s_eff = reversed ? (ne + 1 - s) : s
+            other_i, other_j = _step_in_from_edge(other_edge, s_eff, ne)
+            push!(result, _cube_linear(other_face, other_i, other_j, ne))
+        else
+            # Both axes overflow simultaneously — diagonal through a cube corner
+            # where 3 faces meet. Skip; this is the corner-with-7-neighbours case.
+            continue
+        end
+    end
+
+    return result
+end
+
+has_optimized_neighbour_search(::CubedSphereToplevelTree) = true
+
+#=
+## Lon-lat neighbours
+
+Decode the global linear index assuming column-major i-fast layout
+(`i = mod1(idx, nlon)`, `j = ((idx-1) ÷ nlon) + 1`) — matching how
+`RegularGrid` cells are linearised by `cartesian_to_linear_idx`.
+
+X is normalised before Y so combined wrap + fold corner cases (e.g.
+`(0, nlat+1)` at the top-left of a global grid) resolve correctly: longitude
+wraps first, then the wrapped column folds.
+=#
+
+"""
+    neighbours(w::LonLatConnectivityWrapper, idx::Integer) -> Vector{Int}
+
+Return the linear global indices of cells adjacent to the cell at `idx` on a
+regular lon/lat grid. The exact set depends on the wrapper's `periodic_x`,
+`pole_top_fold`, `pole_bottom_fold` flags:
+
+- Interior cells return 8 neighbours.
+- Periodic-x boundary cells wrap longitudinally.
+- Pole-fold rows route across-pole neighbours via `mod1(i + nlon÷2, nlon)`.
+- Non-periodic / non-fold borders return fewer neighbours (no padding).
+
+When both `nlon ≥ 4` and the relevant flags are set, the 8 offsets always
+resolve to 8 distinct cells. For pathologically small `nlon` (e.g. `nlon = 2`)
+two offsets can collide at a fold row; duplicates are not removed in v1.
+"""
+function neighbours(w::LonLatConnectivityWrapper, idx::Integer)
+    # TODO: replace per-call allocation with preallocated buffer when AbstractNeighbourCache lands
+    nlon = w.nlon
+    nlat = w.nlat
+    periodic_x = w.periodic_x
+    pole_top_fold = w.pole_top_fold
+    pole_bottom_fold = w.pole_bottom_fold
+
+    i = mod1(Int(idx), nlon)
+    j = ((Int(idx) - 1) ÷ nlon) + 1
+
+    result = Int[]
+    sizehint!(result, 8)
+
+    half = nlon ÷ 2
+
+    for (di, dj) in _NEIGHBOUR_OFFSETS
+        i_new = i + di
+        j_new = j + dj
+        valid = true
+
+        # Handle x out-of-range first so combined wrap+fold corners resolve.
+        if i_new < 1 || i_new > nlon
+            if periodic_x
+                i_new = mod1(i_new, nlon)
+            else
+                valid = false
+            end
+        end
+
+        # Then handle y out-of-range, after x has been normalised.
+        if valid && j_new < 1
+            if pole_bottom_fold
+                i_new = mod1(i_new + half, nlon)
+                j_new = 1
+            else
+                valid = false
+            end
+        elseif valid && j_new > nlat
+            if pole_top_fold
+                i_new = mod1(i_new + half, nlon)
+                j_new = nlat
+            else
+                valid = false
+            end
+        end
+
+        if valid
+            push!(result, i_new + (j_new - 1) * nlon)
+        end
+    end
+
+    return result
+end
+
+has_optimized_neighbour_search(::LonLatConnectivityWrapper) = true

--- a/src/trees/neighbours_interface.jl
+++ b/src/trees/neighbours_interface.jl
@@ -1,0 +1,11 @@
+function has_optimized_idx_search end # (grid)::Bool
+function findidx end # (grid, pos)::idx
+function has_optimized_neighbour_search end # (grid)
+function neighbours end # (grid, idx)::idxs
+function dual_neighbours end # (grid, pos, neighbours)::idxs
+
+# Question here: should a cache also exhibit the tree interface?
+# Or be completely separate?
+abstract type AbstractNeighbourCache end
+function neighbours(cache::AbstractNeighbourCache, position) end
+function dual_neighbours(cache::AbstractNeighbourCache, position) end

--- a/src/trees/quadtree_cursors.jl
+++ b/src/trees/quadtree_cursors.jl
@@ -3,6 +3,27 @@ abstract type AbstractQuadtreeCursor end
 
 GOCore.best_manifold(c::AbstractQuadtreeCursor) = GOCore.manifold(getgrid(c))
 
+# Default `should_parallelize` for any cursor (TopDownQuadtreeCursor,
+# IndexOffsetQuadtreeCursor, ReorderedTopDownQuadtreeCursor, QuadtreeCursor):
+# spawn once a subtree's leaf count drops below `total / (nthreads * K)`. With
+# K = 32 we land ~256 tasks on 8 threads — enough for the scheduler to balance
+# work without paying excessive spawn overhead. The cursor carries `.grid`,
+# so we get the root grid's total cell count without needing the root tree.
+# Both `prod(ncells(...))` calls are O(1).
+const _PARALLELIZE_K_DEFAULT = 32
+
+@inline _grid_total_cells(g) = ncells(g, 1) * ncells(g, 2)
+
+function should_parallelize(node::AbstractQuadtreeCursor, extent::GO.UnitSpherical.SphericalCap)
+    threshold = max(1, _grid_total_cells(node.grid) ÷ (Threads.nthreads() * _PARALLELIZE_K_DEFAULT))
+    return prod(ncells(node)) <= threshold
+end
+
+function should_parallelize(node::AbstractQuadtreeCursor, extent::Extents.Extent)
+    threshold = max(1, _grid_total_cells(node.grid) ÷ (Threads.nthreads() * _PARALLELIZE_K_DEFAULT))
+    return prod(ncells(node)) <= threshold
+end
+
 """
     QuadtreeCursor(grid::AbstractCurvilinearGrid)
 

--- a/src/trees/wrappers.jl
+++ b/src/trees/wrappers.jl
@@ -67,37 +67,37 @@ STI.node_extent(w::KnownFullSphereExtentWrapper) = GO.UnitSpherical.SphericalCap
 #=
 ## WithParallelizePolicy
 
-Wraps any spatial tree so that [`should_parallelize`](@ref) for it dispatches
-to a user-supplied callable instead of the default(s) for the inner tree's
-type. This is the instance-level counterpart to defining a tree-type-specific
-`should_parallelize` method — useful for one-off tuning without subtyping.
+Wraps any spatial tree so its `should_parallelize` is supplied by a
+user-provided callable — the instance-level counterpart to defining a
+node-type-specific `should_parallelize` method.
 =#
 
 """
     WithParallelizePolicy(tree, policy)
 
-Wrap `tree` so [`Trees.should_parallelize`](@ref) for it calls
-`policy(tree, node, extent) -> Bool` instead of falling back to the default(s)
-for the inner tree's type.
+Wrap `tree` so the dual-tree DFS uses `policy(tree, node, extent) -> Bool`
+instead of the default `Trees.should_parallelize(node, extent)`.
 
 `policy` returns `true` to spawn a parallel task at `node` and stop
-recursing single-threaded, `false` to keep descending. All other
-SpatialTreeInterface methods forward to the wrapped tree.
+descending single-threaded, `false` to keep descending. The wrapper is
+detected at the dual-DFS call site (`intersection_areas.jl`), which
+builds a local closure capturing `tree` and `policy` — so `policy`
+gets the root tree as its first arg without that becoming a Julia
+dispatch axis.
 
-Use this when you want to tune the multithreading granularity for a
-single regridding call without defining a Julia method on the tree's
-type. For per-type policies, define a `should_parallelize` method on
-the tree type directly.
+All other SpatialTreeInterface methods forward to the wrapped tree
+(`<: AbstractTreeWrapper`).
+
+Use this when you want to tune multithreading granularity for a
+single regridding call without defining a method on a node type.
+For per-node-type policies, define `should_parallelize(::MyNode, extent)`
+directly.
 """
 struct WithParallelizePolicy{T, F} <: AbstractTreeWrapper
     tree::T
     policy::F
 end
 Base.parent(w::WithParallelizePolicy) = w.tree
-# Disambiguate against the extent-typed defaults in interfaces.jl by defining
-# the wrapper method for each shipped extent type. The wrapper's policy wins.
-should_parallelize(w::WithParallelizePolicy, node, extent::Extents.Extent) = w.policy(w.tree, node, extent)
-should_parallelize(w::WithParallelizePolicy, node, extent::GO.UnitSpherical.SphericalCap) = w.policy(w.tree, node, extent)
 
 
 """
@@ -130,6 +130,29 @@ getcell(wrapper::GeometryMaintainingTreeWrapper{G, T}, i::Integer) where {G <: A
 
 
 #=
+## CubeFaceConnectivity
+
+Static connectivity table that records, for each cube edge of each face, which
+neighbouring face/edge it joins and whether the parameterizations along the
+shared edge run in opposite directions.
+
+Edge IDs follow ClimaCore's element-local face numbering:
+1 = south (j_min), 2 = east (i_max), 3 = north (j_max), 4 = west (i_min).
+
+The `ne` field is bundled here so that decoding global indices for a cubed
+sphere only requires the connectivity object.
+=#
+struct CubeFaceConnectivity
+    # indexed [edge, face]; entries are (neighbour_face, neighbour_edge, reversed)
+    table::Matrix{Tuple{Int8, Int8, Bool}}
+    ne::Int
+    function CubeFaceConnectivity(table::Matrix{Tuple{Int8, Int8, Bool}}, ne::Integer)
+        size(table) == (4, 6) || throw(ArgumentError("Connectivity table must be 4×6 (edges × faces); got $(size(table))"))
+        return new(table, Int(ne))
+    end
+end
+
+#=
 ## CubedSphereToplevelTree
 
 A wrapper around a vector of quadtree cursors that represents a cubed sphere.
@@ -139,6 +162,7 @@ It might be replaced by something more general later.
 =#
 struct CubedSphereToplevelTree{V <: AbstractVector{<: Union{<: AbstractTreeWrapper, <: AbstractQuadtreeCursor}}}
     quadtrees::V
+    connectivity::CubeFaceConnectivity
 end
 
 STI.isspatialtree(::Type{<: CubedSphereToplevelTree}) = true

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -126,12 +126,12 @@ end
         polys
     end
 
-    # The planar default errors when no tree-type-specific method is defined.
-    # Test with a synthetic tree type so the assertion is independent of any
-    # method later added in this session.
-    struct _UnsupportedPlanarTree end
+    # The planar default errors when called on a node type that has no
+    # specific method. Use a synthetic node type so this assertion is
+    # independent of any method added later in this session.
+    struct _UnsupportedPlanarNode end
     @test_throws ErrorException ConservativeRegridding.Trees.should_parallelize(
-        _UnsupportedPlanarTree(), nothing, Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0)),
+        _UnsupportedPlanarNode(), Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0)),
     )
 
     # Grids must be large enough that neither tree's top-level cursor is already a
@@ -139,15 +139,20 @@ end
     src = make_grid(8, 8)
     dst = make_grid(16, 16)
 
-    # Define a tree-type-specific policy and confirm it's called during construction.
+    # Inject a tree-aware policy via the `WithParallelizePolicy` wrapper and
+    # confirm it's called during construction. The wrapper is detected at the
+    # dual-DFS call site (intersection_areas.jl) and threaded through a local
+    # closure, so the policy callback gets the root tree as its first arg
+    # without that being a Julia dispatch axis.
     call_count = Ref(0)
-    ConservativeRegridding.Trees.should_parallelize(
-        tree::ConservativeRegridding.Trees.TopDownQuadtreeCursor,
-        node,
-        extent::Extents.Extent,
-    ) = (call_count[] += 1; true)
+    src_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), src)
+    dst_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), dst)
+    src_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+        src_tree, (tree, node, extent) -> (call_count[] += 1; true))
+    dst_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+        dst_tree, (tree, node, extent) -> (call_count[] += 1; true))
 
-    r = ConservativeRegridding.Regridder(GeometryOpsCore.Planar(), dst, src; threaded=true)
+    r = ConservativeRegridding.Regridder(GeometryOpsCore.Planar(), dst_w, src_w; threaded=true)
     @test call_count[] > 0
     @test r isa ConservativeRegridding.Regridder
     @test size(r) == (16*16, 8*8)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test, SafeTestsets
     @safetestset "Unit tests: Regridding" begin include("regridding.jl") end
     @safetestset "Unit tests: Grids" begin include("trees/grids.jl") end
     @safetestset "Unit tests: QuadtreeCursors" begin include("trees/quadtree_cursors.jl") end
+    @safetestset "Unit tests: Neighbours (lon-lat)" begin include("trees/neighbours_lonlat.jl") end
+    @safetestset "Unit tests: Neighbours (cubed sphere)" begin include("trees/neighbours_cubed_sphere.jl") end
 
     @safetestset "Extensions: Oceananigans" begin include("extensions/oceananigans.jl") end
     @safetestset "Extensions: ClimaCore" begin include("extensions/climacore.jl") end

--- a/test/trees/neighbours_cubed_sphere.jl
+++ b/test/trees/neighbours_cubed_sphere.jl
@@ -1,0 +1,136 @@
+using ConservativeRegridding
+using ConservativeRegridding: Trees
+using ConservativeRegridding.Trees: neighbours, has_optimized_neighbour_search
+using Test
+using Random
+import GeometryOps as GO
+
+using ClimaCore:
+    CommonSpaces, Fields, Spaces, Meshes, Topologies, Domains, ClimaComms
+
+# Helper: build a `Topology2D` and the corresponding `CubedSphereToplevelTree`.
+function build_cubed_sphere(ne::Integer)
+    context = ClimaComms.context()
+    h_mesh = Meshes.EquiangularCubedSphere(
+        Domains.SphereDomain{Float64}(GO.Spherical().radius),
+        ne,
+    )
+    h_topology = Topologies.Topology2D(context, h_mesh)
+    space = CommonSpaces.CubedSphereSpace(;
+        radius = h_mesh.domain.radius,
+        n_quad_points = 2,
+        h_elem = ne,
+        h_mesh,
+        h_topology,
+    )
+    tree = Trees.treeify(GO.Spherical(), space)
+    return tree, h_topology
+end
+
+# Helper: decode a global cubed-sphere linear index to (face, i, j).
+function decode_cube(idx::Integer, ne::Integer)
+    ne2 = ne * ne
+    face = ((idx - 1) ÷ ne2) + 1
+    face_local = ((idx - 1) % ne2) + 1
+    i = mod1(face_local, ne)
+    j = ((face_local - 1) ÷ ne) + 1
+    return (face, i, j)
+end
+
+@inline _cube_lin(F, i, j, ne) = i + (j - 1) * ne + (F - 1) * ne^2
+
+@testset "Connectivity table pinned values" begin
+    tree, _ = build_cubed_sphere(2)
+    table = tree.connectivity.table
+    @test tree.connectivity.ne == 2
+    # Edge IDs: 1=S, 2=E, 3=N, 4=W
+    # Face 1 row from the design doc.
+    @test table[1, 1] == (Int8(6), Int8(3), true)
+    @test table[2, 1] == (Int8(2), Int8(4), true)
+    @test table[3, 1] == (Int8(3), Int8(4), true)
+    @test table[4, 1] == (Int8(5), Int8(3), true)
+    # Face 5 row from the design doc.
+    @test table[1, 5] == (Int8(4), Int8(3), true)
+    @test table[2, 5] == (Int8(6), Int8(4), true)
+    @test table[3, 5] == (Int8(1), Int8(4), true)
+    @test table[4, 5] == (Int8(3), Int8(3), true)
+
+    @test has_optimized_neighbour_search(tree) == true
+end
+
+@testset "Interior-of-face cells (ne=4) — 8 neighbours from arithmetic" begin
+    ne = 4
+    tree, _ = build_cubed_sphere(ne)
+    # Pick (F=1, i=2, j=2): strict interior on face 1.
+    F, i, j = 1, 2, 2
+    idx = _cube_lin(F, i, j, ne)
+    nbrs = neighbours(tree, idx)
+    @test length(nbrs) == 8
+    expected = Set{Int}([
+        _cube_lin(F, i,   j-1, ne), _cube_lin(F, i+1, j-1, ne),
+        _cube_lin(F, i+1, j,   ne), _cube_lin(F, i+1, j+1, ne),
+        _cube_lin(F, i,   j+1, ne), _cube_lin(F, i-1, j+1, ne),
+        _cube_lin(F, i-1, j,   ne), _cube_lin(F, i-1, j-1, ne),
+    ])
+    @test Set(nbrs) == expected
+end
+
+@testset "Edge-of-face non-corner cells — 8 nbrs, 3 cross-face" begin
+    ne = 4
+    tree, topology = build_cubed_sphere(ne)
+    # Pick the south edge of face 1 at i=2 (non-corner): (F=1, i=2, j=1).
+    F, i, j = 1, 2, 1
+    idx = _cube_lin(F, i, j, ne)
+    nbrs = neighbours(tree, idx)
+    @test length(nbrs) == 8
+
+    # Three of the eight neighbours decode to a face other than F.
+    cross = filter(n -> decode_cube(n, ne)[1] != F, nbrs)
+    @test length(cross) == 3
+    # And those three should each lie on the face we expect from the table.
+    other_face_expected = tree.connectivity.table[1, F][1]  # south edge → table[1, F]
+    @test all(decode_cube(n, ne)[1] == other_face_expected for n in cross)
+end
+
+@testset "Corner cells return exactly 7 neighbours (all faces)" begin
+    ne = 4
+    tree, _ = build_cubed_sphere(ne)
+    for F in 1:6
+        for (i, j) in ((1, 1), (1, ne), (ne, 1), (ne, ne))
+            idx = _cube_lin(F, i, j, ne)
+            nbrs = neighbours(tree, idx)
+            @test length(nbrs) == 7
+        end
+    end
+end
+
+@testset "Symmetry on a sample of cells" begin
+    ne = 4
+    tree, _ = build_cubed_sphere(ne)
+    rng = Random.MersenneTwister(0)
+    ncells = 6 * ne^2
+    sample = rand(rng, 1:ncells, 200)
+    for a in sample
+        for b in neighbours(tree, a)
+            @test a in neighbours(tree, b)
+        end
+    end
+end
+
+@testset "Scale test: ne=64 cubed sphere" begin
+    ne = 64
+    tree, _ = build_cubed_sphere(ne)
+    ncells = 6 * ne^2
+    rng = Random.MersenneTwister(123)
+    sample = rand(rng, 1:ncells, 1000)
+    for a in sample
+        nbrs = neighbours(tree, a)
+        @test length(nbrs) in (7, 8)
+    end
+    # Symmetry on the sample.
+    for a in sample
+        for b in neighbours(tree, a)
+            @test a in neighbours(tree, b)
+        end
+    end
+end

--- a/test/trees/neighbours_lonlat.jl
+++ b/test/trees/neighbours_lonlat.jl
@@ -1,0 +1,169 @@
+using ConservativeRegridding.Trees
+using ConservativeRegridding.Trees: neighbours, has_optimized_neighbour_search
+using Test
+using Random
+import GeometryOps as GO
+import GeometryOps: SpatialTreeInterface as STI
+
+# Helper: build a wrapper from x, y vectors and a manifold.
+function make_lonlat_wrapper(x, y; manifold = GO.Spherical())
+    grid = RegularGrid(manifold, x, y)
+    tree = TopDownQuadtreeCursor(grid)
+    return LonLatConnectivityWrapper(tree)
+end
+
+# Helper: linear index from (i, j).
+@inline _lin(i, j, nlon) = i + (j - 1) * nlon
+
+@testset "LonLatConnectivityWrapper inference" begin
+    # Global grid, 8 lon × 4 lat cells. Bounds end at the poles, nlon even.
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    @test w.periodic_x       == true
+    @test w.pole_top_fold    == true
+    @test w.pole_bottom_fold == true
+    @test w.nlon == 8
+    @test w.nlat == 4
+    @test has_optimized_neighbour_search(w) == true
+end
+
+@testset "Interior cell — 8 neighbours, exact indices" begin
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    nlon = w.nlon
+    # Pick a strict-interior cell: (i, j) = (3, 2) for an 8×4 grid.
+    i, j = 3, 2
+    idx = _lin(i, j, nlon)
+    expected = Set{Int}([
+        _lin(i,   j-1, nlon), _lin(i+1, j-1, nlon),
+        _lin(i+1, j,   nlon), _lin(i+1, j+1, nlon),
+        _lin(i,   j+1, nlon), _lin(i-1, j+1, nlon),
+        _lin(i-1, j,   nlon), _lin(i-1, j-1, nlon),
+    ])
+    nbrs = neighbours(w, idx)
+    @test length(nbrs) == 8
+    @test Set(nbrs) == expected
+end
+
+@testset "i = 1 — 8 neighbours via x-wrap" begin
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    nlon = w.nlon
+    i, j = 1, 2
+    idx = _lin(i, j, nlon)
+    nbrs = neighbours(w, idx)
+    @test length(nbrs) == 8
+    # The west-side neighbours should wrap to i = nlon.
+    @test _lin(nlon, j,   nlon) in nbrs
+    @test _lin(nlon, j-1, nlon) in nbrs
+    @test _lin(nlon, j+1, nlon) in nbrs
+end
+
+@testset "Top row j = nlat — pole fold" begin
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    nlon, nlat = w.nlon, w.nlat
+    half = nlon ÷ 2
+    i = 4 # not at a wrap edge
+    j = nlat
+    idx = _lin(i, j, nlon)
+    nbrs = neighbours(w, idx)
+    @test length(nbrs) == 8
+    # 2 same-row + 3 below + 3 across-pole at j = nlat.
+    same_row     = (_lin(i-1, j, nlon), _lin(i+1, j, nlon))
+    below        = (_lin(i-1, j-1, nlon), _lin(i, j-1, nlon), _lin(i+1, j-1, nlon))
+    across_pole_is = mod1.(i .+ (-1:1) .+ half, nlon)
+    across_pole  = (_lin(across_pole_is[1], j, nlon),
+                    _lin(across_pole_is[2], j, nlon),
+                    _lin(across_pole_is[3], j, nlon))
+    expected = Set{Int}(vcat(collect(same_row), collect(below), collect(across_pole)))
+    @test Set(nbrs) == expected
+end
+
+@testset "Top-left corner (1, nlat) — combined wrap + fold" begin
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    nlon, nlat = w.nlon, w.nlat
+    i, j = 1, nlat
+    idx = _lin(i, j, nlon)
+    nbrs = neighbours(w, idx)
+    @test length(nbrs) == 8
+    # All 8 should be distinct at this nlon (= 8).
+    @test length(Set(nbrs)) == 8
+end
+
+@testset "Non-global grid: all flags false" begin
+    x = collect(range(0.0, 90.0; length = 5))
+    y = collect(range(0.0, 45.0; length = 4))
+    w = make_lonlat_wrapper(x, y)
+    @test w.periodic_x       == false
+    @test w.pole_top_fold    == false
+    @test w.pole_bottom_fold == false
+    nlon = w.nlon
+    # Border at (1, 1): only (i+1, 1), (1, j+1), (i+1, j+1) are valid.
+    nbrs = neighbours(w, _lin(1, 1, nlon))
+    @test length(nbrs) == 3
+    @test Set(nbrs) == Set{Int}([
+        _lin(2, 1, nlon),
+        _lin(1, 2, nlon),
+        _lin(2, 2, nlon),
+    ])
+end
+
+@testset "Odd-nlon global grid: folds forced false" begin
+    nlon = 17
+    nlat = 8
+    x = collect(range(-180.0, 180.0; length = nlon + 1))
+    y = collect(range(-90.0,  90.0; length = nlat + 1))
+    w = make_lonlat_wrapper(x, y)
+    @test w.periodic_x       == true
+    @test w.pole_top_fold    == false
+    @test w.pole_bottom_fold == false
+    # Top row cell — no fold means j = nlat returns 5 neighbours
+    # (2 same row + 3 below).
+    i = 5
+    nbrs = neighbours(w, _lin(i, nlat, nlon))
+    @test length(nbrs) == 5
+end
+
+@testset "Symmetry round-trip on global grid" begin
+    x = collect(range(-180.0, 180.0; length = 9))
+    y = collect(range(-90.0,  90.0; length = 5))
+    w = make_lonlat_wrapper(x, y)
+    ncells = w.nlon * w.nlat
+    rng_idxs = vcat(1:ncells)  # exhaustive on this small grid
+    for a in rng_idxs
+        for b in neighbours(w, a)
+            @test a in neighbours(w, b)
+        end
+    end
+end
+
+@testset "Scale test: lon-lat 720×360" begin
+    nlon, nlat = 720, 360
+    x = collect(range(-180.0, 180.0; length = nlon + 1))
+    y = collect(range(-90.0,  90.0; length = nlat + 1))
+    w = make_lonlat_wrapper(x, y)
+    @test w.periodic_x       == true
+    @test w.pole_top_fold    == true
+    @test w.pole_bottom_fold == true
+
+    # Sample 1000 random cells. Global + even nlon means all should have 8 neighbours.
+    rng = Random.MersenneTwister(42)
+    sample = rand(rng, 1:(nlon * nlat), 1000)
+    for a in sample
+        nbrs = neighbours(w, a)
+        @test length(nbrs) == 8
+    end
+    # Symmetry on the sample.
+    for a in sample
+        for b in neighbours(w, a)
+            @test a in neighbours(w, b)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Three logically distinct improvements to the base library, bundled because they share the underlying tree infrastructure:

1. **Allocation-free spherical `cell_range_extent`** via a `PerimeterPoints` iterator — drops a per-call O(perimeter) allocation in the dual-DFS hot path.
2. **Default leaf-count `should_parallelize(node, extent)`** on `AbstractQuadtreeCursor` — replaces the per-tree-type override with a node-typed default that spawns a parallel task once a subtree's leaf count drops below `total_cells / (nthreads * 32)`. The `WithParallelizePolicy` wrapper becomes an instance-level escape hatch detected at the dual-DFS call site (no longer a Julia dispatch axis).
3. **`Trees.neighbours` interface** — returns the indices of cells sharing a vertex (or edge) with a given cell, for cubed-sphere and lon-lat grids. Cubed-sphere connectivity is built once by the ClimaCore extension via `Topologies.opposing_face` and cached on `CubedSphereToplevelTree`.

This is split out of the larger `as/newapi` branch (#93). The 2nd-order conservative regridding work that consumes the neighbours API will land in a follow-up PR stacked on this one.

## Test plan

- [x] `test/trees/neighbours_lonlat.jl` — 9284 / 9284 pass
- [x] `test/trees/neighbours_cubed_sphere.jl` — 10600 / 10600 pass
- [x] `test/regridding.jl` — 23 / 23 pass (covers the `WithParallelizePolicy` redesign)
- [ ] Full `runtests.jl` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)