### PR TITLE
Tree-search improvements: allocation-free spherical extents + leaf-count should_parallelize

### DIFF
--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -31,13 +31,27 @@ function compute_intersection_areas(
     return ret_i1, ret_i2, ret_area
 end
 
+# If the root tree is a `WithParallelizePolicy`, route the dual-DFS's
+# `(node, extent)` query through the user policy; otherwise fall back to the
+# default `should_parallelize` dispatch. The wrapper is *not* a dispatch axis
+# on `should_parallelize` — detecting it here keeps the dispatch graph simple.
+@inline function _build_parallelize_closure(tree)
+    if tree isa Trees.WithParallelizePolicy
+        let inner = tree.tree, p = tree.policy
+            return (node, extent) -> p(inner, node, extent)
+        end
+    else
+        return (node, extent) -> Trees.should_parallelize(node, extent)
+    end
+end
+
 function get_all_candidate_pairs(threaded::True, predicate_f::F, src_tree::T1, dst_tree::T2) where {F, T1, T2}
     # TODO: Threaded dual dfs via chunking.
     # For now this is just serial, and is the big bottleneck for larger grids.
     # First, run the dual depth first search to get all candidate pairs of
     # cells that may intersect.
-    par_src = (node, extent) -> Trees.should_parallelize(src_tree, node, extent)
-    par_dst = (node, extent) -> Trees.should_parallelize(dst_tree, node, extent)
+    par_src = _build_parallelize_closure(src_tree)
+    par_dst = _build_parallelize_closure(dst_tree)
     candidate_idxs = multithreaded_dual_query(predicate_f, par_src, par_dst, src_tree, dst_tree) # from utils/MultithreadedDualDepthFirstSearch.jl
     return candidate_idxs
 end

--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -173,78 +173,133 @@ Since we know our grids are curvilinear, this is broadly okay.  It's not perfect
 =#
 
 using LinearAlgebra
+
+#=
+Spherical `cell_range_extent` machinery.
+
+The bounding-cap algorithm needs the four corners of the index rectangle plus
+points sampled along its perimeter (because cell edges follow constant-lat /
+constant-lon, not great-circles, so they bulge differently). Earlier versions
+materialized the perimeter into a fresh `Vector` per call — that drove most of
+the GC pressure in the dual-DFS hot path.
+
+Now the perimeter is a stack-resident iterator (`PerimeterPoints`) that yields
+points on demand via a small per-grid `_pt_at` method, and the cap builder
+consumes any iterator over `UnitSphericalPoint`s. No buffers, no shared state,
+threadsafe by construction.
+=#
+
+# Per-grid: materialize the UnitSphericalPoint at point-index (i, j).
+@inline _pt_at(g::RegularGrid{<: GO.Spherical}, i::Int, j::Int) =
+    GO.UnitSphereFromGeographic()((g.x[i], g.y[j]))
+@inline _pt_at(g::CellBasedGrid{<: GO.Spherical}, i::Int, j::Int) =
+    @inbounds g.points[i, j]
+
+# Perimeter iterator: walks the four sides of the [imin..imax] × [jmin..jmax]
+# index rectangle in order (west column, east column, north row, south row),
+# skipping degenerate sides. Yields the `_pt_at(grid, i, j)` for each border
+# point. State is `(side::Int, k::Int)`; `side > 4` signals exhaustion.
+struct PerimeterPoints{G}
+    grid::G
+    imin::Int
+    imax::Int
+    jmin::Int
+    jmax::Int
+end
+
+Base.IteratorSize(::Type{<: PerimeterPoints}) = Base.HasLength()
+function Base.length(p::PerimeterPoints)
+    nrow = p.imax - p.imin + 1
+    ncol = p.jmax - p.jmin + 1
+    n = ncol                                       # west column
+    n += (p.imax != p.imin) * ncol                 # east column
+    n += (p.jmax != p.jmin) * nrow * 2             # north + south rows
+    return n
+end
+Base.eltype(::Type{PerimeterPoints{G}}) where {G} =
+    Core.Compiler.return_type(_pt_at, Tuple{G, Int, Int})
+
+@inline function Base.iterate(p::PerimeterPoints, state = (1, p.jmin))
+    while true
+        side, k = state
+        if side == 1                               # west: (imin, k)
+            k <= p.jmax && return _pt_at(p.grid, p.imin, k), (1, k + 1)
+            state = (2, p.jmin)
+        elseif side == 2                           # east: (imax, k)
+            (p.imax != p.imin && k <= p.jmax) &&
+                return _pt_at(p.grid, p.imax, k), (2, k + 1)
+            state = (3, p.imin)
+        elseif side == 3                           # north: (k, jmax)
+            (p.jmax != p.jmin && k <= p.imax) &&
+                return _pt_at(p.grid, k, p.jmax), (3, k + 1)
+            state = (4, p.imin)
+        elseif side == 4                           # south: (k, jmin)
+            (p.jmax != p.jmin && k <= p.imax) &&
+                return _pt_at(p.grid, k, p.jmin), (4, k + 1)
+            return nothing
+        else
+            return nothing
+        end
+    end
+end
+
+"""
+    circle_from_four_corners(corner_points, other_points)
+
+Bounding `SphericalCap` covering 4 cell corners passed in (BL, TL, BR, TR) order
+plus an iterable of additional perimeter points. `corner_points` and the
+elements of `other_points` may be `UnitSphericalPoint`s or `(lon, lat)` tuples
+— `UnitSphereFromGeographic` is a no-op on already-converted points.
+
+Public for use by extensions (e.g. `HealpixExt`) that build trees out of
+arbitrary 4-corner polygons. Internally a thin wrapper over [`_spherical_cap`].
+"""
 function circle_from_four_corners(corner_points, other_points)
     raw = GO.UnitSphereFromGeographic().(corner_points)
-    # corner_points arrive as (BL, TL, BR, TR); reorder to CCW (BL, BR, TR, TL)
-    # so that consecutive slerps give bottom, right, top, left edge midpoints.
+    # Reorder (BL, TL, BR, TR) → CCW (SW, SE, NE, NW) for slerp midpoints.
     p1, p2, p3, p4 = raw[1], raw[3], raw[4], raw[2]
-    center = LinearAlgebra.normalize((p1 .+ p2 .+ p3 .+ p4) ./ 4)
-    # Midpoints of edges (bottom, right, top, left)
+    return _spherical_cap(p1, p2, p3, p4,
+        (GO.UnitSphereFromGeographic()(p) for p in other_points))
+end
+
+# Build a SphericalCap covering 4 CCW corners (SW, SE, NE, NW), the slerp
+# midpoints of their 4 edges (great-circle bulge), and every point yielded by
+# `perimeter` (constant-lat/lon bulge along cell sides).
+@inline function _spherical_cap(p1, p2, p3, p4, perimeter)
+    center = LinearAlgebra.normalize((p1 + p2 + p3 + p4) / 4)
     p12 = GO.UnitSpherical.slerp(p1, p2, 0.5)
     p23 = GO.UnitSpherical.slerp(p2, p3, 0.5)
     p34 = GO.UnitSpherical.slerp(p3, p4, 0.5)
     p41 = GO.UnitSpherical.slerp(p4, p1, 0.5)
-    # Distance to the furthest corner or edge midpoint
-    corner_distance = maximum(p -> GO.spherical_distance(center, p), (p1, p2, p3, p4, p12, p23, p34, p41))
-    # Distance to the furthest other point
-    other_distance = maximum(p -> GO.spherical_distance(center, p), GO.UnitSphereFromGeographic().(other_points); init = corner_distance)
-    # Distance to the furthest point
-    distance = max(corner_distance, other_distance)
-    #The `*1.0001` is done to not miss intersections through numerical inaccuracies
-    return GO.UnitSpherical.SphericalCap(center, distance*1.0001)
+    d = max(
+        GO.spherical_distance(center, p1), GO.spherical_distance(center, p2),
+        GO.spherical_distance(center, p3), GO.spherical_distance(center, p4),
+        GO.spherical_distance(center, p12), GO.spherical_distance(center, p23),
+        GO.spherical_distance(center, p34), GO.spherical_distance(center, p41),
+    )
+    for p in perimeter
+        d = max(d, GO.spherical_distance(center, p))
+    end
+    # The 1.0001 slack guards against missed intersections from rounding error.
+    return GO.UnitSpherical.SphericalCap(center, d * 1.0001)
 end
 
 function cell_range_extent(q::CellBasedGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    imin, imax = extrema(irange)
-    jmin, jmax = extrema(jrange)
-    # For cell based we need 1 to the max indices from cell space
-    # to get the max indices in point space (`(n,m) -> (n+1, m+1)`)
-    imax += 1
-    jmax += 1
-
-    quadtree_points = q.points
-    corner_points = (quadtree_points[imin, jmin], quadtree_points[imin, jmax], quadtree_points[imax, jmin], quadtree_points[imax, jmax])
-
-    # Collect points from all border rows/columns
-    other_points = typeof(GI.getpoint(GI.getexterior(getcell(q, imin, jmin)), 1))[]
-    sizehint!(other_points, 2 * (imax - imin + 1) + 2 * (jmax - jmin + 1))
-    # Left and right columns (all rows)
-    append!(other_points, view(q.points, imin, jmin:jmax))
-    if imax != imin
-        append!(other_points, view(q.points, imax, jmin:jmax))
-    end
-    # Top and bottom rows (all columns)
-    if jmax != jmin
-        append!(other_points, view(q.points, imin:imax, jmax))
-        append!(other_points, view(q.points, imin:imax, jmin))
-    end
-    return circle_from_four_corners(corner_points, other_points)
+    imin, imax = extrema(irange); imax += 1
+    jmin, jmax = extrema(jrange); jmax += 1
+    return _spherical_cap(
+        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
+        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
+        PerimeterPoints(q, imin, imax, jmin, jmax),
+    )
 end
 
 function cell_range_extent(q::RegularGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    imin, imax = extrema(irange)
-    jmin, jmax = extrema(jrange)
-    # For cell based we need 1 to the max indices from cell space 
-    # to get the max indices in point space (`(n,m) -> (n+1, m+1)`)
-    imax += 1
-    jmax += 1
-
-    corner_points = ((q.x[imin], q.y[jmin]), (q.x[imin], q.y[jmax]), (q.x[imax], q.y[jmin]), (q.x[imax], q.y[jmax]))
-
-    # Collect points from all border polygons
-    other_points = typeof(GI.getpoint(GI.getexterior(getcell(q, imin, jmin)), 1))[]
-    sizehint!(other_points, (imax - imin + 1) * (jmax - jmin + 1))
-    # Top and bottom rows (all columns)
-    append!(other_points, tuple.(q.x[imin], q.y[jmin:jmax]))
-    if imax != imin
-        append!(other_points, tuple.(q.x[imax], q.y[jmin:jmax]))
-    end
-    if jmax != jmin
-        append!(other_points, tuple.(q.x[imin:imax], q.y[jmax]))
-    end
-    # Bottom row (all columns) - needed for correct cap near poles
-    if jmin != jmax
-        append!(other_points, tuple.(q.x[imin:imax], q.y[jmin]))
-    end
-    return circle_from_four_corners(corner_points, other_points)
+    imin, imax = extrema(irange); imax += 1
+    jmin, jmax = extrema(jrange); jmax += 1
+    return _spherical_cap(
+        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
+        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
+        PerimeterPoints(q, imin, imax, jmin, jmax),
+    )
 end

--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -34,7 +34,7 @@ to the manifold the grid lives on.
 
 A grid that is built from a matrix of pre-computed polygons.  This is the most explicit method with the least optimizations, but it is the most flexible.
 """
-struct ExplicitPolygonGrid{M <: GOCore.Manifold, PolyMatrixType <: AbstractMatrix} <: AbstractCurvilinearGrid
+struct ExplicitPolygonGrid{M <: GOCore.Manifold, PolyMatrixType <: AbstractMatrix} <: AbstractCurvilinearGrid{M}
     manifold::M
     polygons::PolyMatrixType
 end
@@ -54,7 +54,7 @@ because it knows the corner points of each polygon.
 
 For a cell based grid with n by m cells, the points matrix will have n+1 by m+1 points.
 """
-struct CellBasedGrid{M <: GOCore.Manifold, PointMatrixType <: AbstractMatrix} <: AbstractCurvilinearGrid
+struct CellBasedGrid{M <: GOCore.Manifold, PointMatrixType <: AbstractMatrix} <: AbstractCurvilinearGrid{M}
     manifold::M
     points::PointMatrixType
 end
@@ -93,7 +93,7 @@ This is optimized for regular grids but requires unit-spherical transforms
 to be run on each call to `node_extent` - so it might be better to use a
 [`CellBasedGrid`](@ref) instead if performance is a concern.
 """
-struct RegularGrid{M <: GOCore.Manifold, DX, DY} <: AbstractCurvilinearGrid
+struct RegularGrid{M <: GOCore.Manifold, DX, DY} <: AbstractCurvilinearGrid{M}
     manifold::M
     x::DX
     y::DY
@@ -177,29 +177,32 @@ using LinearAlgebra
 #=
 Spherical `cell_range_extent` machinery.
 
-The bounding-cap algorithm needs the four corners of the index rectangle plus
-points sampled along its perimeter (because cell edges follow constant-lat /
-constant-lon, not great-circles, so they bulge differently). Earlier versions
-materialized the perimeter into a fresh `Vector` per call — that drove most of
-the GC pressure in the dual-DFS hot path.
+The bounding cap must cover the four corners of the index rectangle and the points
+sampled along its perimeter — cell edges follow constant-lat / constant-lon, not
+great circles, so they bulge differently. Earlier versions materialized the perimeter
+into a fresh `Vector` per call, which drove most of the GC pressure in the dual-DFS
+hot path.
 
-Now the perimeter is a stack-resident iterator (`PerimeterPoints`) that yields
-points on demand via a small per-grid `_pt_at` method, and the cap builder
-consumes any iterator over `UnitSphericalPoint`s. No buffers, no shared state,
-threadsafe by construction.
+Instead each vertex is accessed on demand through the per-grid `getvertex` interface
+method, and the border is walked with the stack-resident `CurvilinearGridPerimeterPoints`
+iterator. The cap builder folds `max`-distance over the corners and that iterator — no
+buffers, no shared state, threadsafe by construction.
 =#
 
-# Per-grid: materialize the UnitSphericalPoint at point-index (i, j).
-@inline _pt_at(g::RegularGrid{<: GO.Spherical}, i::Int, j::Int) =
+# `getvertex` interface methods (interfaces.jl) for the structured spherical grids —
+# the one piece of per-grid variation the bounding-cap code below dispatches on.
+@inline getvertex(g::RegularGrid{<: GO.Spherical}, i::Int, j::Int) =
     GO.UnitSphereFromGeographic()((g.x[i], g.y[j]))
-@inline _pt_at(g::CellBasedGrid{<: GO.Spherical}, i::Int, j::Int) =
+@inline getvertex(g::CellBasedGrid{<: GO.Spherical}, i::Int, j::Int) =
     @inbounds g.points[i, j]
 
-# Perimeter iterator: walks the four sides of the [imin..imax] × [jmin..jmax]
-# index rectangle in order (west column, east column, north row, south row),
-# skipping degenerate sides. Yields the `_pt_at(grid, i, j)` for each border
-# point. State is `(side::Int, k::Int)`; `side > 4` signals exhaustion.
-struct PerimeterPoints{G}
+# Lazy iterator over the border-ring vertices of the point block
+# [imin..imax] × [jmin..jmax], in order: west column, east column, then the
+# interiors of the south and north rows (so each of the 4 corners is yielded once,
+# by the columns). Built on `getvertex`, so it works for any grid implementing the
+# interface. State is a single linear index `n`; the `n → (i,j)` map is plain
+# arithmetic and iteration ends once `n` passes `length`.
+struct CurvilinearGridPerimeterPoints{G}
     grid::G
     imin::Int
     imax::Int
@@ -207,40 +210,25 @@ struct PerimeterPoints{G}
     jmax::Int
 end
 
-Base.IteratorSize(::Type{<: PerimeterPoints}) = Base.HasLength()
-function Base.length(p::PerimeterPoints)
-    nrow = p.imax - p.imin + 1
-    ncol = p.jmax - p.jmin + 1
-    n = ncol                                       # west column
-    n += (p.imax != p.imin) * ncol                 # east column
-    n += (p.jmax != p.jmin) * nrow * 2             # north + south rows
-    return n
-end
-Base.eltype(::Type{PerimeterPoints{G}}) where {G} =
-    Core.Compiler.return_type(_pt_at, Tuple{G, Int, Int})
+Base.IteratorSize(::Type{<: CurvilinearGridPerimeterPoints}) = Base.HasLength()
+# A W×H point block has 2W + 2H − 4 border vertices (corners counted once).
+Base.length(p::CurvilinearGridPerimeterPoints) =
+    2 * (p.imax - p.imin + 1) + 2 * (p.jmax - p.jmin + 1) - 4
 
-@inline function Base.iterate(p::PerimeterPoints, state = (1, p.jmin))
-    while true
-        side, k = state
-        if side == 1                               # west: (imin, k)
-            k <= p.jmax && return _pt_at(p.grid, p.imin, k), (1, k + 1)
-            state = (2, p.jmin)
-        elseif side == 2                           # east: (imax, k)
-            (p.imax != p.imin && k <= p.jmax) &&
-                return _pt_at(p.grid, p.imax, k), (2, k + 1)
-            state = (3, p.imin)
-        elseif side == 3                           # north: (k, jmax)
-            (p.jmax != p.jmin && k <= p.imax) &&
-                return _pt_at(p.grid, k, p.jmax), (3, k + 1)
-            state = (4, p.imin)
-        elseif side == 4                           # south: (k, jmin)
-            (p.jmax != p.jmin && k <= p.imax) &&
-                return _pt_at(p.grid, k, p.jmin), (4, k + 1)
-            return nothing
-        else
-            return nothing
-        end
+@inline function Base.iterate(p::CurvilinearGridPerimeterPoints, n::Int = 1)
+    n > length(p) && return nothing
+    H = p.jmax - p.jmin + 1
+    W = p.imax - p.imin + 1
+    if n <= H
+        i, j = p.imin, p.jmin + n - 1                # west column (incl. both W corners)
+    elseif n <= 2H
+        i, j = p.imax, p.jmin + (n - H) - 1          # east column (incl. both E corners)
+    elseif n <= 2H + (W - 2)
+        i, j = p.imin + (n - 2H), p.jmin             # south row interior
+    else
+        i, j = p.imin + (n - 2H - (W - 2)), p.jmax   # north row interior
     end
+    return getvertex(p.grid, i, j), n + 1
 end
 
 """
@@ -284,22 +272,16 @@ end
     return GO.UnitSpherical.SphericalCap(center, d * 1.0001)
 end
 
-function cell_range_extent(q::CellBasedGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
+# Bounding cap for a range of cells on any spherical curvilinear grid: the four
+# corners, their great-circle edge midpoints, and the perimeter vertices of the
+# index rectangle. One generic method — concrete grids supply only `getvertex`.
+# (`ExplicitPolygonGrid{<: GO.Spherical}` keeps its own, more-specific method above.)
+function cell_range_extent(g::AbstractCurvilinearGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
     imin, imax = extrema(irange); imax += 1
     jmin, jmax = extrema(jrange); jmax += 1
     return _spherical_cap(
-        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
-        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
-        PerimeterPoints(q, imin, imax, jmin, jmax),
-    )
-end
-
-function cell_range_extent(q::RegularGrid{<: GO.Spherical}, irange::UnitRange{Int}, jrange::UnitRange{Int})
-    imin, imax = extrema(irange); imax += 1
-    jmin, jmax = extrema(jrange); jmax += 1
-    return _spherical_cap(
-        _pt_at(q, imin, jmin), _pt_at(q, imax, jmin),
-        _pt_at(q, imax, jmax), _pt_at(q, imin, jmax),
-        PerimeterPoints(q, imin, imax, jmin, jmax),
+        getvertex(g, imin, jmin), getvertex(g, imax, jmin),
+        getvertex(g, imax, jmax), getvertex(g, imin, jmax),
+        CurvilinearGridPerimeterPoints(g, imin, imax, jmin, jmax),
     )
 end

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -19,65 +19,74 @@ import Extents
 import SortTileRecursiveTree # in order to implement the `getcell/ncell` interface
 
 """
-    should_parallelize(tree, node, extent) -> Bool
+    should_parallelize(node, extent) -> Bool
 
-Decide whether to spawn a parallel task at `node` of `tree` during the
-multithreaded dual-tree traversal used to find candidate intersecting
-cell pairs.
+Decide whether to spawn a parallel task at `node` during the multithreaded
+dual-tree traversal used to find candidate intersecting cell pairs.
 
 Returning `true` means *this node is the granularity at which a task is
-spawned*: the dual DFS stops descending recursively into children for
-the purpose of further parallelism and runs the subtree as a single
-parallel unit. Returning `false` means *keep descending* — the node is
-still too coarse and a task at this level would create unbalanced work.
+spawned*: the dual DFS stops descending recursively into children for the
+purpose of further parallelism and runs the subtree as a single parallel
+unit. Returning `false` means *keep descending* — the node is still too
+coarse and a task at this level would create unbalanced work.
 
 `extent` is the bounding region of `node` (e.g. an `Extents.Extent` for
 planar grids or a `SphericalCap` for spherical grids). It is passed
 explicitly so implementations and the dual DFS share one computation per
 node.
 
+Dispatch is on `(node_type, extent_type)` only — the root tree is *not*
+a dispatch axis. To express tree-aware logic (e.g. "spawn when subtree
+covers ≤ 1/N of the root grid"), wrap the root tree with
+[`WithParallelizePolicy`](@ref); the wrapper plumbs the tree into a
+local closure that the dual DFS calls without participating in dispatch.
+
 # Defaults
 
-- `extent::SphericalCap`: spawns once the cap covers less than ¼ of the
-  unit sphere — a heuristic that avoids spawning a single task at the
-  root. This works because spherical caps have a natural upper bound
-  (the full unit sphere is ~4π steradians) against which "small enough"
-  has a fixed meaning.
-- `extent::Extents.Extent`: errors. Planar extents have no canonical
-  scale — a "unit square" might be 1 metre, 1 degree, or 10⁹ metres —
-  and there is no upper or lower bound on the magnitude of an `Extent`,
-  so no manifold-agnostic default can decide "small enough" without
-  knowing the tree's own notion of size. Tree authors must supply
-  their own method.
+- `(::AbstractQuadtreeCursor, ::SphericalCap | ::Extents.Extent)`: leaf-count
+  test using `node.grid` for total cells. Spawns once the subtree covers
+  ≤ `prod(ncells(node.grid)) ÷ (Threads.nthreads() * 32)` leaves. Defined
+  in `quadtree_cursors.jl`.
+- `(::Any, ::SphericalCap)`: spawns once the cap covers less than ¼ of the
+  unit sphere — a coarse heuristic for foreign tree types where leaf count
+  isn't cheap.
+- `(::Any, ::Extents.Extent)`: errors. Planar extents have no canonical
+  scale — tree authors must supply their own method (or wrap with
+  [`WithParallelizePolicy`](@ref)).
 
 # Customization
 
-Override per tree type by adding a more-specific method:
+Two paths:
 
-```julia
-ConservativeRegridding.Trees.should_parallelize(
-    tree::MyTree, node, extent::Extents.Extent,
-) = prod(ncells(node)) ≤ prod(ncells(getgrid(tree))) ÷ (Threads.nthreads() * 4)
-```
+1. **Tree-type-specific override** — define a node-type-specific method:
 
-…or wrap any tree at construction time with [`WithParallelizePolicy`](@ref)
-to supply an instance-level callable without defining a method:
+   ```julia
+   ConservativeRegridding.Trees.should_parallelize(
+       node::MyCursorType, extent::Extents.Extent,
+   ) = prod(ncells(node)) ≤ prod(ncells(node.grid)) ÷ (Threads.nthreads() * 4)
+   ```
 
-```julia
-tree_with_policy = WithParallelizePolicy(my_tree, (node, extent) -> ...)
-```
+2. **Instance-level wrapper** — wrap the root tree at construction time:
+
+   ```julia
+   tree_with_policy = WithParallelizePolicy(my_tree, (tree, node, extent) -> ...)
+   ```
+
+   The wrapper plumbs the policy through the dual DFS via a local closure
+   in `intersection_areas.jl`, so it doesn't participate in dispatch.
 """
 function should_parallelize end
 
-should_parallelize(tree, node, extent::GO.UnitSpherical.SphericalCap) =
+should_parallelize(node, extent::GO.UnitSpherical.SphericalCap) =
     (2π * (1 - cos(extent.radius))) < π
 
-should_parallelize(tree, node, extent::Extents.Extent) = error(
+should_parallelize(node, extent::Extents.Extent) = error(
     """
-    `Trees.should_parallelize` has no method for planar `Extents.Extent` on tree of type `$(typeof(tree))`.
-    Planar trees must define a tree-type-specific method, e.g. 
-    `ConservativeRegridding.Trees.should_parallelize(::$(typeof(tree)), node, extent::Extents.Extent) = ...`
-    to control multithreading granularity.
+    `Trees.should_parallelize` has no method for planar `Extents.Extent` on node of type `$(typeof(node))`.
+    Either define a node-type-specific method:
+        `ConservativeRegridding.Trees.should_parallelize(::$(typeof(node)), extent::Extents.Extent) = ...`
+    or wrap your tree with `WithParallelizePolicy(tree, policy)` to supply an
+    instance-level callable.
     """
 )
 

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -141,9 +141,11 @@ Implementations of `AbstractCurvilinearGrid` are [`Trees.RegularGrid`](@ref), [`
 =#
 
 """
-    abstract type AbstractCurvilinearGrid
+    abstract type AbstractCurvilinearGrid{M <: GOCore.Manifold}
 
-Abstract supertype for all curvilinear grid types.
+Abstract supertype for all curvilinear grid types, parameterized by the manifold `M`
+(e.g. `Planar`, `Spherical`) the grid lives on, so algorithms can dispatch on the
+manifold — see the generic spherical [`Trees.cell_range_extent`](@ref).
 The type itself should store the representation of the "base" of the quadtree,
 which should fit into the `QuadtreeCursor` type.
 
@@ -162,7 +164,7 @@ cell_range_extent(grid, irange::UnitRange{Int}, jrange::UnitRange{Int})
 
 and then you may also want to specialize on `STI.node_extent(::QuadtreeCursor{<: YourQuadtreeType}) -> GO.UnitSpherical.SphericalCap{Float64}`
 """
-abstract type AbstractCurvilinearGrid end
+abstract type AbstractCurvilinearGrid{M <: GOCore.Manifold} end
 
 """
     getcell(grid::AbstractCurvilinearGrid, i::Int, j::Int) -> GI.Polygon
@@ -199,6 +201,23 @@ Get the extent of the cells in the given range of indices.
 """
 function cell_range_extent(grid::AbstractCurvilinearGrid, irange::UnitRange{Int}, jrange::UnitRange{Int})
     error("cell_range_extent not implemented for $(typeof(grid))")
+end
+
+"""
+    getvertex(grid::AbstractCurvilinearGrid, i::Int, j::Int)
+
+Get the grid vertex at *point-index* `(i, j)`. Point indices run `1:(n+1) × 1:(m+1)`
+for an `n × m` cell grid — one more than the cell count per dimension, since adjacent
+cells share corners. For spherical grids this returns a
+`GO.UnitSpherical.UnitSphericalPoint`.
+
+Part of the [`Trees.AbstractCurvilinearGrid`](@ref) interface (sibling to
+[`Trees.getcell`](@ref)), used by the spherical [`Trees.cell_range_extent`](@ref) to
+build bounding caps from the corners and `CurvilinearGridPerimeterPoints` of an index
+range. Structured grids on the sphere should implement it; planar grids need not.
+"""
+function getvertex(grid::AbstractCurvilinearGrid, i::Int, j::Int)
+    error("getvertex not implemented for $(typeof(grid))")
 end
 
 # ### Generic higher-level implementations

--- a/src/trees/quadtree_cursors.jl
+++ b/src/trees/quadtree_cursors.jl
@@ -3,6 +3,27 @@ abstract type AbstractQuadtreeCursor end
 
 GOCore.best_manifold(c::AbstractQuadtreeCursor) = GOCore.manifold(getgrid(c))
 
+# Default `should_parallelize` for any cursor (TopDownQuadtreeCursor,
+# IndexOffsetQuadtreeCursor, ReorderedTopDownQuadtreeCursor, QuadtreeCursor):
+# spawn once a subtree's leaf count drops below `total / (nthreads * K)`. With
+# K = 32 we land ~256 tasks on 8 threads — enough for the scheduler to balance
+# work without paying excessive spawn overhead. The cursor carries `.grid`,
+# so we get the root grid's total cell count without needing the root tree.
+# Both `prod(ncells(...))` calls are O(1).
+const _PARALLELIZE_K_DEFAULT = 32
+
+@inline _grid_total_cells(g) = ncells(g, 1) * ncells(g, 2)
+
+function should_parallelize(node::AbstractQuadtreeCursor, extent::GO.UnitSpherical.SphericalCap)
+    threshold = max(1, _grid_total_cells(node.grid) ÷ (Threads.nthreads() * _PARALLELIZE_K_DEFAULT))
+    return prod(ncells(node)) <= threshold
+end
+
+function should_parallelize(node::AbstractQuadtreeCursor, extent::Extents.Extent)
+    threshold = max(1, _grid_total_cells(node.grid) ÷ (Threads.nthreads() * _PARALLELIZE_K_DEFAULT))
+    return prod(ncells(node)) <= threshold
+end
+
 """
     QuadtreeCursor(grid::AbstractCurvilinearGrid)
 

--- a/src/trees/wrappers.jl
+++ b/src/trees/wrappers.jl
@@ -67,37 +67,37 @@ STI.node_extent(w::KnownFullSphereExtentWrapper) = GO.UnitSpherical.SphericalCap
 #=
 ## WithParallelizePolicy
 
-Wraps any spatial tree so that [`should_parallelize`](@ref) for it dispatches
-to a user-supplied callable instead of the default(s) for the inner tree's
-type. This is the instance-level counterpart to defining a tree-type-specific
-`should_parallelize` method — useful for one-off tuning without subtyping.
+Wraps any spatial tree so its `should_parallelize` is supplied by a
+user-provided callable — the instance-level counterpart to defining a
+node-type-specific `should_parallelize` method.
 =#
 
 """
     WithParallelizePolicy(tree, policy)
 
-Wrap `tree` so [`Trees.should_parallelize`](@ref) for it calls
-`policy(tree, node, extent) -> Bool` instead of falling back to the default(s)
-for the inner tree's type.
+Wrap `tree` so the dual-tree DFS uses `policy(tree, node, extent) -> Bool`
+instead of the default `Trees.should_parallelize(node, extent)`.
 
 `policy` returns `true` to spawn a parallel task at `node` and stop
-recursing single-threaded, `false` to keep descending. All other
-SpatialTreeInterface methods forward to the wrapped tree.
+descending single-threaded, `false` to keep descending. The wrapper is
+detected at the dual-DFS call site (`intersection_areas.jl`), which
+builds a local closure capturing `tree` and `policy` — so `policy`
+gets the root tree as its first arg without that becoming a Julia
+dispatch axis.
 
-Use this when you want to tune the multithreading granularity for a
-single regridding call without defining a Julia method on the tree's
-type. For per-type policies, define a `should_parallelize` method on
-the tree type directly.
+All other SpatialTreeInterface methods forward to the wrapped tree
+(`<: AbstractTreeWrapper`).
+
+Use this when you want to tune multithreading granularity for a
+single regridding call without defining a method on a node type.
+For per-node-type policies, define `should_parallelize(::MyNode, extent)`
+directly.
 """
 struct WithParallelizePolicy{T, F} <: AbstractTreeWrapper
     tree::T
     policy::F
 end
 Base.parent(w::WithParallelizePolicy) = w.tree
-# Disambiguate against the extent-typed defaults in interfaces.jl by defining
-# the wrapper method for each shipped extent type. The wrapper's policy wins.
-should_parallelize(w::WithParallelizePolicy, node, extent::Extents.Extent) = w.policy(w.tree, node, extent)
-should_parallelize(w::WithParallelizePolicy, node, extent::GO.UnitSpherical.SphericalCap) = w.policy(w.tree, node, extent)
 
 
 """

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -308,12 +308,12 @@ end
         polys
     end
 
-    # The planar default errors when no tree-type-specific method is defined.
-    # Test with a synthetic tree type so the assertion is independent of any
-    # method later added in this session.
-    struct _UnsupportedPlanarTree end
+    # The planar default errors when called on a node type that has no
+    # specific method. Use a synthetic node type so this assertion is
+    # independent of any method added later in this session.
+    struct _UnsupportedPlanarNode end
     @test_throws ErrorException ConservativeRegridding.Trees.should_parallelize(
-        _UnsupportedPlanarTree(), nothing, Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0)),
+        _UnsupportedPlanarNode(), Extents.Extent(X=(0.0, 1.0), Y=(0.0, 1.0)),
     )
 
     # Grids must be large enough that neither tree's top-level cursor is already a
@@ -321,15 +321,20 @@ end
     src = make_grid(8, 8)
     dst = make_grid(16, 16)
 
-    # Define a tree-type-specific policy and confirm it's called during construction.
+    # Inject a tree-aware policy via the `WithParallelizePolicy` wrapper and
+    # confirm it's called during construction. The wrapper is detected at the
+    # dual-DFS call site (intersection_areas.jl) and threaded through a local
+    # closure, so the policy callback gets the root tree as its first arg
+    # without that being a Julia dispatch axis.
     call_count = Ref(0)
-    ConservativeRegridding.Trees.should_parallelize(
-        tree::ConservativeRegridding.Trees.TopDownQuadtreeCursor,
-        node,
-        extent::Extents.Extent,
-    ) = (call_count[] += 1; true)
+    src_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), src)
+    dst_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), dst)
+    src_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+        src_tree, (tree, node, extent) -> (call_count[] += 1; true))
+    dst_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+        dst_tree, (tree, node, extent) -> (call_count[] += 1; true))
 
-    r = ConservativeRegridding.Regridder(GeometryOpsCore.Planar(), dst, src; threaded=true)
+    r = ConservativeRegridding.Regridder(GeometryOpsCore.Planar(), dst_w, src_w; threaded=true)
     @test call_count[] > 0
     @test r isa ConservativeRegridding.Regridder
     @test size(r) == (16*16, 8*8)

--- a/test/trees/grids.jl
+++ b/test/trees/grids.jl
@@ -1,3 +1,4 @@
+import ConservativeRegridding
 using ConservativeRegridding.Trees
 using ConservativeRegridding.Trees: cell_range_extent
 using Test
@@ -191,5 +192,80 @@ end
         @test ext.X[2] ≈ 0.75
         @test ext.Y[1] ≈ 0.0
         @test ext.Y[2] ≈ 2 / 3
+    end
+end
+
+# ===========================================================================
+# Spherical bounding-cap machinery: getvertex + CurvilinearGridPerimeterPoints
+# (replacing the private `_pt_at` accessor and the `PerimeterPoints` state machine).
+# ===========================================================================
+import GeometryOps as GO
+import LinearAlgebra
+
+# Regional spherical grids — chosen away from poles/antipodes so the bounding cap
+# is non-degenerate. (A pole-to-pole range has antipodal corners whose mean is the
+# origin, giving a NaN center; that pre-existing edge case is out of scope here.)
+const _SPH_LONS = collect(range(0.0, 40.0, length = 5))   # 4 cells along i
+const _SPH_LATS = collect(range(0.0, 30.0, length = 4))   # 3 cells along j
+const _SPH_LONLAT = [(lon, lat) for lon in _SPH_LONS, lat in _SPH_LATS]
+const _SPH_PTS = GO.UnitSphereFromGeographic().(_SPH_LONLAT)
+_regular_sph()   = RegularGrid(GOCore.Spherical(), _SPH_LONS, _SPH_LATS)
+_cellbased_sph() = CellBasedGrid(_SPH_PTS)   # UnitSphericalPoint eltype ⇒ Spherical
+
+@testset "cell_range_extent spherical: bounding cap (characterization)" begin
+    pts = _SPH_PTS
+    for (ir, jr) in ((1:4, 1:3), (1:1, 1:1), (2:3, 1:2), (1:4, 2:2), (1:2, 1:3))
+        imin, imax = first(ir), last(ir) + 1
+        jmin, jmax = first(jr), last(jr) + 1
+        expected_center = LinearAlgebra.normalize(
+            (pts[imin, jmin] + pts[imax, jmin] + pts[imax, jmax] + pts[imin, jmax]) / 4)
+        for g in (_regular_sph(), _cellbased_sph())
+            cap = cell_range_extent(g, ir, jr)
+            # the cap must bound every vertex of the requested cell range …
+            @test all(GO.spherical_distance(cap.point, pts[i, j]) <= cap.radius
+                      for i in imin:imax, j in jmin:jmax)
+            # … and be centered on the normalized mean of the 4 range corners
+            @test isapprox(cap.point, expected_center; atol = 1e-12)
+        end
+    end
+end
+
+@testset "getvertex returns the vertex at point-index (i,j)" begin
+    cbg = _cellbased_sph()
+    rg  = _regular_sph()
+    gv  = ConservativeRegridding.Trees.getvertex
+    # CellBasedGrid stores the points directly
+    @test gv(cbg, 1, 1) == _SPH_PTS[1, 1]
+    @test gv(cbg, 2, 3) == _SPH_PTS[2, 3]
+    @test gv(cbg, 5, 4) == _SPH_PTS[5, 4]
+    # RegularGrid converts (lon, lat) → unit sphere on demand
+    @test gv(rg, 1, 1) == GO.UnitSphereFromGeographic()((_SPH_LONS[1], _SPH_LATS[1]))
+    @test gv(rg, 2, 3) == GO.UnitSphereFromGeographic()((_SPH_LONS[2], _SPH_LATS[3]))
+    @test gv(rg, 5, 4) == GO.UnitSphereFromGeographic()((_SPH_LONS[5], _SPH_LATS[4]))
+end
+
+# Expected border-ring (i,j) order: west column, east column, then the interiors
+# of the south and north rows (so each corner is yielded once, by the columns).
+function _expected_ring_ij(imin, imax, jmin, jmax)
+    ij = Tuple{Int,Int}[]
+    for j in jmin:jmax;         push!(ij, (imin, j)); end   # west column
+    for j in jmin:jmax;         push!(ij, (imax, j)); end   # east column
+    for i in (imin + 1):(imax - 1); push!(ij, (i, jmin)); end  # south row interior
+    for i in (imin + 1):(imax - 1); push!(ij, (i, jmax)); end  # north row interior
+    return ij
+end
+
+@testset "CurvilinearGridPerimeterPoints yields the border ring in order" begin
+    cbg = _cellbased_sph()
+    pts = _SPH_PTS
+    PP  = ConservativeRegridding.Trees.CurvilinearGridPerimeterPoints
+    # full grid, sub-range, single cell, thin-in-i (W=2), thin-in-j (H=2)
+    for (imin, imax, jmin, jmax) in
+            ((1, 5, 1, 4), (2, 4, 1, 3), (1, 2, 1, 2), (1, 2, 1, 4), (1, 5, 2, 3))
+        it = PP(cbg, imin, imax, jmin, jmax)
+        expected = [pts[i, j] for (i, j) in _expected_ring_ij(imin, imax, jmin, jmax)]
+        @test collect(it) == expected
+        @test length(it) == length(expected)
+        @test length(it) == 2 * (imax - imin + 1) + 2 * (jmax - jmin + 1) - 4
     end
 end


### PR DESCRIPTION
## Summary

Two logically distinct improvements to the spatial-tree machinery, extracted from `as/part1-base-and-neighbours` so they can land without the neighbours API.

- **Allocation-free spherical `cell_range_extent`** via a `PerimeterPoints` iterator — drops a per-call O(perimeter) allocation in the dual-DFS hot path. The bounding-cap builder now consumes any iterator over `UnitSphericalPoint`s instead of materializing a fresh vector.
- **Default leaf-count `should_parallelize`** for `AbstractQuadtreeCursor` — replaces the per-tree-type override with a node-typed default that spawns a parallel task once a subtree's leaf count drops below `total_cells / (nthreads * 32)`. The `WithParallelizePolicy` wrapper becomes an instance-level escape hatch detected at the dual-DFS call site (a local closure in `intersection_areas.jl`), so it no longer needs to be a Julia dispatch axis on `should_parallelize`.

## Files changed

| File | What |
|---|---|
| `src/trees/grids.jl` | `PerimeterPoints` iterator + lean `_spherical_cap` |
| `src/trees/interfaces.jl` | `should_parallelize(node, extent)` (2-arg) |
| `src/trees/quadtree_cursors.jl` | Default leaf-count policy for `AbstractQuadtreeCursor` |
| `src/trees/wrappers.jl` | `WithParallelizePolicy` docstring + drop of dispatch methods |
| `src/regridder/intersection_areas.jl` | `_build_parallelize_closure` (wrapper detected at call site) |
| `test/regridding.jl` | `#66` testset ported to the new node-typed signature via `WithParallelizePolicy` |

## Test plan

- [x] Full local test suite: **2543 pass / 4 broken / 2547 total** (4 broken matches pre-existing main count)
- [ ] CI green
- [ ] `WithParallelizePolicy` wrapper testset still exercises wrapper detection
- [ ] `#66` regression testset still exercises planar threaded regridding

🤖 Generated with [Claude Code](https://claude.com/claude-code)