### PR TITLE
Parallelize ClimaCore sparse matrix assembly + polygon intersections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,13 @@ Trees Module (grid representations + quadtree cursors for spatial indexing)
 
 **`intersection_areas`** (`intersection_areas.jl`): Two-phase approach:
 1. Dual DFS through spatial trees to find candidate cell pairs (extent-based pruning)
-2. Parallel intersection area computation on candidates, partitioned into `nthreads * 4` chunks via ChunkSplitters
+2. Parallel COO assembly on candidates, partitioned into `nthreads * 4` chunks via ChunkSplitters, fetched and `vcat`-reduced into a `SparseMatrixCSC`
 
-**Intersection operators** dispatch on manifold:
-- Planar: `FosterHormannClipping`
-- Spherical: `ConvexConvexSutherlandHodgman`
+**Intersection operator interface** (one trait + two hooks, all with defaults; the operator is the single extensible concept that drives assembly):
+- `IntersectionReturnStyle(op)` — `OutOfPlaceSingleResult` (default; `op(src_cell, dst_cell) -> area`, driver stores the triplet) vs `InPlace` (`op(rows, cols, vals, item, src_tree, dst_tree)` pushes its own COO). Resolved once at the top of `intersection_areas` and threaded through.
+- `work_items(op, candidate_pairs)` — units of parallel work (default: one candidate pair each).
+- `output_matrix_size(op, src_tree, dst_tree)` — assembled `(nrows, ncols)` (default: dst-cells × src-cells).
+- These are `@public`. `DefaultIntersectionOperator` dispatches on manifold (Planar: `FosterHormannClipping`, Spherical: `ConvexConvexSutherlandHodgman`) and uses all defaults.
 
 ### Trees Module (`src/trees/Trees.jl`)
 
@@ -103,11 +105,11 @@ The manifold affects extent computation, intersection algorithms, and area calcu
 All follow the same pattern: implement `Trees.treeify()` for domain-specific grid types.
 
 - **OceananigansExt**: LatitudeLongitudeGrid, RectilinearGrid, TripolarGrid → vertex matrices wrapped in KnownFullSphereExtentWrapper
-- **ClimaCoreExt**: Cubed sphere topologies → per-face cursors with index remapping
+- **ClimaCoreExt**: Cubed sphere topologies → per-face cursors with index remapping. Also provides custom `Regridder` constructors for spectral-element (SE) spaces: SE↔FV regridding is assembled by two `InPlace` intersection operators (`SEToFVIntersectionOperator`, `FVToSEIntersectionOperator`) that plug into the shared `intersection_areas` driver — FV→SE overrides `work_items` to make each element (not each candidate pair) the unit of parallel work for its local mass-matrix solve.
 - **HealpixExt**, **RingGridsExt**: HEALPix and SpeedyWeather grids
 - **SpeedyWeatherExt**: Requires *both* RingGrids and SpeedyWeather loaded (dual weak dependency)
 - **InterfacesExt**: Interfaces.jl contracts
 
 ### API Surface
 
-The package uses `@public` from SciMLPublic for API visibility: `Regridder`, `regrid`, `regrid!`, `areas` are public. Grid types and tree types are exported.
+The package uses `@public` from SciMLPublic for API visibility: `Regridder`, `regrid`, `regrid!`, `areas` are public, as is the intersection-operator interface (`intersection_areas`, `DefaultIntersectionOperator`, `IntersectionReturnStyle`, `OutOfPlaceSingleResult`, `InPlace`, `work_items`, `output_matrix_size`). Grid types and tree types are exported.

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.2.5"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Milan Kloewer <milankloewer@gmx.de>", "Simone Silvestri <silvestri.simone0@gmail.com>", "and contributors"]
 
 [workspace]
-projects = ["test", "docs", "lib/ConservativeRegriddingTestHelpers"]
+projects = ["test", "docs", "bench", "lib/ConservativeRegriddingTestHelpers"]
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"

--- a/bench/CondaPkg.toml
+++ b/bench/CondaPkg.toml
@@ -1,0 +1,3 @@
+[deps]
+esmpy = ""
+esmf = ""

--- a/bench/Project.toml
+++ b/bench/Project.toml
@@ -1,0 +1,24 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Chairmarks = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
+ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+ConservativeRegridding = "8e50ac2c-eb48-49bc-a402-07c87b949343"
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+GeometryOps = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
+GeometryOpsCore = "05efe853-fabf-41c8-927e-7063c8b9f013"
+Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
+LibGEOS = "a90b1aa1-3769-5649-ba7e-abc5a9d163eb"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+RingGrids = "d1845624-ad4f-453b-8ff4-a8db365bf3a7"
+SphericalSpatialTrees = "86b7679e-e8c0-4ea9-ad3d-baef5c69eb57"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+XESMF = "2e0b0046-e7a1-486f-88de-807ee8ffabe5"
+
+[sources]
+ConservativeRegridding = {path = ".."}
+SphericalSpatialTrees = {rev = "main", url = "https://github.com/meggart/SphericalSpatialTrees.jl"}

--- a/bench/spectral_element.jl
+++ b/bench/spectral_element.jl
@@ -1,0 +1,82 @@
+# Construction-cost benchmark for spectral-element regridders vs the plain
+# finite-volume baseline.
+#
+#     julia --project=docs bench/spectral_element.jl
+#
+# (the `docs` environment carries ClimaCore + Oceananigans + Chairmarks.)
+#
+# For each resolution tier it times `Regridder(dst, src)` — the dual-tree
+# candidate search plus sparse intersection-matrix assembly — for three cases:
+#
+#     FV → FV   LatitudeLongitudeGrid          → LatitudeLongitudeGrid
+#     SE → FV   cubed-sphere spectral element  → LatitudeLongitudeGrid
+#     FV → SE   LatitudeLongitudeGrid          → cubed-sphere spectral element
+#
+# SE↔FV assembly does strictly more work than FV→FV (per intersection polygon it
+# fan-triangulates and runs a Gauss rule against the SE Lagrange basis), so it is
+# expected to be slower and allocate more; this script quantifies the gap.
+
+using ConservativeRegridding
+using Chairmarks
+using Printf
+import GeometryOps as GO
+import SparseArrays
+using Oceananigans: LatitudeLongitudeGrid
+using ClimaCore: CommonSpaces, Meshes, Domains, Topologies, ClimaComms
+
+const RADIUS   = GO.Spherical().radius
+const N_QUAD   = 4       # GLL points per direction (Nq)
+const THREADED = true    # flip to false to measure serial assembly
+
+# cubed-sphere `h_elem` paired with a target lon×lat grid
+const TIERS = [
+    (; h_elem = 8,  nlon = 72,  nlat = 36),
+    (; h_elem = 16, nlon = 144, nlat = 72),
+    (; h_elem = 32, nlon = 288, nlat = 144),
+]
+
+latlon(nlon, nlat) = LatitudeLongitudeGrid(
+    size = (nlon, nlat, 1), longitude = (0, 360), latitude = (-90, 90),
+    z = (0, 1), radius = RADIUS,
+)
+
+function cubedsphere_space(h_elem)
+    context    = ClimaComms.context()
+    h_mesh     = Meshes.EquiangularCubedSphere(Domains.SphereDomain{Float64}(RADIUS), h_elem)
+    h_topology = Topologies.Topology2D(context, h_mesh)
+    return CommonSpaces.CubedSphereSpace(;
+        radius = RADIUS, n_quad_points = N_QUAD, h_elem, h_mesh, h_topology,
+    )
+end
+
+# Build once (compile + correctness + nnz), then time the construction.
+function time_construction(name, dst, src)
+    R = ConservativeRegridding.Regridder(dst, src; threaded = THREADED)
+    s = @b ConservativeRegridding.Regridder($dst, $src; threaded = $THREADED)
+    return (; name, time = s.time, allocs = s.allocs, bytes = s.bytes,
+            nnz = SparseArrays.nnz(R.intersections))
+end
+
+function run()
+    @printf("%-5s  %-8s  %10s  %12s  %9s  %10s\n",
+            "tier", "case", "time", "allocs", "memory", "nnz")
+    println("-"^64)
+    for t in TIERS
+        fv     = latlon(t.nlon, t.nlat)                  # common FV destination
+        fv_src = latlon(cld(t.nlon, 2), cld(t.nlat, 2))  # coarser FV source
+        se     = cubedsphere_space(t.h_elem)
+        tier   = "h$(t.h_elem)"
+
+        for r in (time_construction("FV → FV", fv, fv_src),
+                  time_construction("SE → FV", fv, se),
+                  time_construction("FV → SE", se, fv))
+            @printf("%-5s  %-8s  %8.1f ms  %12d  %6.1f MB  %10d\n",
+                    tier, r.name, r.time * 1e3, round(Int, r.allocs),
+                    r.bytes / 2^20, r.nnz)
+        end
+        @printf("       cubed sphere: %d elems / %d SE nodes;  FV dst: %d cells\n\n",
+                6 * t.h_elem^2, 6 * t.h_elem^2 * N_QUAD^2, t.nlon * t.nlat)
+    end
+end
+
+run()

--- a/docs/src/how_it_works.md
+++ b/docs/src/how_it_works.md
@@ -51,4 +51,79 @@ assembled into a sparse matrix which is the regridder object.
 
 Success!  We have now constructed a regridder.  There are a couple of steps after this, normalization and so on, but those are more details.
 
+## Customizing the weights: the intersection operator interface
+
+Step 3 above is driven by a single extensible object — the **intersection operator** —
+plus three dispatched seams, each with a default that reproduces the area-based weight.
+The operator is passed as `Regridder(dst, src; intersection_operator = ...)`, or directly
+to [`ConservativeRegridding.intersection_areas`](@ref). The three seams are:
+
+1. **[`IntersectionReturnStyle`](@ref)`(op)`** — how the operator delivers a contribution
+   for one work item:
+   - [`OutOfPlaceSingleResult`](@ref) (the default): the operator is a function
+     `op(src_cell, dst_cell) -> area::Real`, and the driver stores the COO triplet.
+   - [`InPlace`](@ref): the operator is
+     `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` and pushes its own COO
+     contributions directly.
+2. **[`work_items`](@ref)`(op, candidate_pairs)`** — the units of work the parallel loop
+   iterates over (default: one candidate `(src, dst)` pair per unit). Override it to change
+   the parallel granularity — e.g. to group all of a source element's candidate cells into
+   a single work unit.
+3. **[`output_matrix_size`](@ref)`(op, src_tree, dst_tree)`** — the `(nrows, ncols)` shape
+   of the assembled matrix (default: destination-cell count × source-cell count).
+
+Everything else — candidate search, chunking, multithreaded assembly, and sparse-matrix
+construction — is shared, so whatever your operator computes runs inside the same parallel
+skeleton as the built-in area weights.
+
+### The simple case (`OutOfPlaceSingleResult`)
+
+[`OutOfPlaceSingleResult`](@ref) is the default style, so a custom scalar-weight operator
+only needs to be callable; the defaults handle work units and matrix shape:
+
+```julia
+using ConservativeRegridding
+import GeometryOps as GO
+
+# Reuse the built-in area weight, scaled by a constant factor.
+struct ScaledAreaOperator
+    factor::Float64
+end
+(op::ScaledAreaOperator)(src_cell, dst_cell) =
+    op.factor * ConservativeRegridding.DefaultIntersectionOperator(GO.Spherical())(src_cell, dst_cell)
+
+regridder = ConservativeRegridding.Regridder(dst, src; intersection_operator = ScaledAreaOperator(2.0))
+```
+
+### Emitting a block (`InPlace`)
+
+When one work item should contribute several matrix entries — as the ClimaCore
+spectral-element assemblers do, emitting an `Nq²` block per intersection — declare the
+operator [`InPlace`](@ref) and `push!` directly onto the COO vectors:
+
+```julia
+struct MyBlockOperator
+    nrows::Int
+    ncols::Int
+end
+ConservativeRegridding.IntersectionReturnStyle(::MyBlockOperator) = ConservativeRegridding.InPlace()
+ConservativeRegridding.output_matrix_size(op::MyBlockOperator, ::Any, ::Any) = (op.nrows, op.ncols)
+
+function (op::MyBlockOperator)(rows, cols, vals, (i_src, i_dst), src_tree, dst_tree)
+    src_cell = ConservativeRegridding.Trees.getcell(src_tree, i_src)
+    dst_cell = ConservativeRegridding.Trees.getcell(dst_tree, i_dst)
+    weight = ConservativeRegridding.DefaultIntersectionOperator(GO.Spherical())(src_cell, dst_cell)
+    # A real block emitter pushes several (row, col, value) entries per work item;
+    # here we push a single one to illustrate the mechanics.
+    push!(rows, i_dst)
+    push!(cols, i_src)
+    push!(vals, weight)
+    return nothing
+end
+```
+
+The ClimaCore extension (`SE → FV` and `FV → SE` regridding) is built entirely on this
+interface: each direction is an `InPlace` operator, and `FV → SE` additionally overrides
+[`work_items`](@ref) to make the per-element mass-matrix solve the unit of parallel work.
+
 ## How we actually do it

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -123,3 +123,18 @@ In ConservativeRegridding.jl:
 ConservativeRegridding.Regridder
 ConservativeRegridding.regrid!
 ```
+
+### Intersection operator interface
+
+These functions let you plug a custom weight kernel into the shared parallel assembly.
+See [Customizing the weights: the intersection operator interface](@ref) for a walkthrough.
+
+```@docs
+ConservativeRegridding.intersection_areas
+ConservativeRegridding.DefaultIntersectionOperator
+ConservativeRegridding.IntersectionReturnStyle
+ConservativeRegridding.OutOfPlaceSingleResult
+ConservativeRegridding.InPlace
+ConservativeRegridding.work_items
+ConservativeRegridding.output_matrix_size
+```

--- a/ext/ConservativeRegriddingClimaCoreExt.jl
+++ b/ext/ConservativeRegriddingClimaCoreExt.jl
@@ -19,10 +19,7 @@ import ClimaCore.Utilities: linear_ind
 """
     coords_for_face(mesh::CubedSphereMesh, face_idx)::Matrix{UnitSphericalPoint}
 
-Get the normalized coordinates of each element vertex for a face of a cubed sphere.
-
-For example, if the cubed sphere has 8 elements in each dimension of a panel (face),
-this function will return a matrix of 9x9 points, each with normalized coordinates.
+Normalized vertex coordinates for a cubed-sphere face: an `(ne+1)×(ne+1)` matrix of points.
 """
 function coords_for_face(mesh::Meshes.AbstractCubedSphere, face_idx)
     ne = mesh.ne
@@ -104,17 +101,11 @@ Trees.treeify(manifold::GOCore.Spherical, field::ClimaCore.Fields.Field) = Trees
 """
     flat_nodal_data(data::DataLayouts.AbstractData) → Vector
 
-Flatten nodal storage to a `Vector` using ClimaCore’s [`DataLayouts.data2array`](@ref),
-which matches the memory layout (for `IJFH`-style data this is `i` fastest, then `j`,
-then remaining horizontal indices).
-
-For layouts with a vertical dimension (`VIJFH`, etc.), `data2array` is an ``N_v \\times N_h``
-matrix; we take the first vertical level so behavior matches the previous explicit
-`view(parent, :, :, 1, 1, :)` slicing.
-
-For scalar fields you can equivalently use `Fields.field2array(field)`; this helper
-accepts raw `AbstractData` (e.g. `Fields.field_values(coords.lat)` or
-`Spaces.weighted_jacobian(space)`).
+Flatten nodal storage to a `Vector` via [`DataLayouts.data2array`](@ref) (memory layout:
+for `IJFH`, `i` fastest, then `j`, then horizontal indices). For layouts with a vertical
+dimension (`VIJFH`, etc.) `data2array` is an ``N_v \\times N_h`` matrix; the first vertical
+level is taken. Unlike `Fields.field2array`, accepts raw `AbstractData` (e.g.
+`Fields.field_values(coords.lat)`, `Spaces.weighted_jacobian(space)`).
 """
 function flat_nodal_data(data::DataLayouts.AbstractData)
     array = DataLayouts.data2array(data)
@@ -130,9 +121,8 @@ end
 """
     se_node_positions(space) → Vector{UnitSphericalPoint}
 
-Extract the lat/lon positions of all spectral element nodes as a flat vector of
-`UnitSphericalPoint`s.  Ordering: all Nq² nodes of element 1 (i fastest),
-then element 2, etc.
+Positions of all SE nodes as a flat vector. Ordering: all Nq² nodes of element 1
+(i fastest), then element 2, etc.
 """
 function se_node_positions(space)
     coords = Fields.coordinate_field(space)
@@ -145,8 +135,8 @@ end
 """
     se_node_weights(space) → Vector{Float64}
 
-Extract the Jacobian integration weights ``W_{e,i,j}`` for all SE nodes as a
-flat vector.  Same ordering as [`se_node_positions`](@ref).
+Jacobian integration weights ``W_{e,i,j}`` for all SE nodes as a flat vector.
+Same ordering as [`se_node_positions`](@ref).
 """
 function se_node_weights(space)
     wj = Spaces.weighted_jacobian(space)
@@ -160,12 +150,10 @@ end
 """
     element_face_local_indices(topology, elem_idx) -> (face, ie, je)
 
-Return the cubed-sphere face (1–6) and the element's local 2D indices
-`(ie, je)` within that face for the global element index `elem_idx`.
-Reads `topology.elemorder`, which encodes the actual element layout —
-either face-major `CartesianIndices((ne, ne, 6))` or a space-filling-curve
-permutation `Vector{CartesianIndex{3}}`. This makes the mapping correct
-for both regular and Gilbert-ordered topologies.
+Cubed-sphere face (1–6) and local 2D indices `(ie, je)` for global element `elem_idx`.
+Reads `topology.elemorder` (face-major `CartesianIndices((ne, ne, 6))` or a space-filling
+permutation `Vector{CartesianIndex{3}}`), so it is correct for both regular and
+Gilbert-ordered topologies.
 """
 function element_face_local_indices(topology::Topologies.Topology2D, elem_idx::Int)
     ci = topology.elemorder[elem_idx]
@@ -175,15 +163,12 @@ end
 """
     inverse_element_map(space, elem_idx, x) -> (ξ, η)
 
-Given a 3D point `x` on the sphere known to lie inside element `elem_idx`,
-return its element-local reference coordinates `(ξ, η) ∈ [-1, 1]²`.
-
-Delegates to `ClimaCore.Meshes.reference_coordinates`, which handles both
-`IntrinsicMap` (closed-form equiangular inversion) and `NormalizedBilinearMap`
-(bilinear-invert against the four corner positions, the default for cubed
-spheres). Both maps share the same vertex positions, so corner GLL nodes
-agree under either; interior nodes differ, which is why a hand-rolled
-equiangular-only inverse fails for the default mesh.
+Element-local reference coordinates `(ξ, η) ∈ [-1, 1]²` of a 3D sphere point `x` known to
+lie inside element `elem_idx`. Delegates to `ClimaCore.Meshes.reference_coordinates`, which
+handles both `IntrinsicMap` (closed-form equiangular inversion) and `NormalizedBilinearMap`
+(bilinear-invert against the four corners; the cubed-sphere default). The two maps agree at
+corner GLL nodes but differ at interior nodes, so a hand-rolled equiangular-only inverse
+fails for the default mesh.
 """
 function inverse_element_map(space::ClimaCore.Spaces.AbstractSpectralElementSpace,
                              elem_idx::Int, x)
@@ -207,14 +192,13 @@ end
 """
     element_jacobian_at(space, elem_idx, ξ, η) -> Float64
 
-Evaluate the SE element's Jacobian at reference coordinates `(ξ, η)` by
-Lagrange interpolation from the nodal weighted-Jacobian values stored on
-`space` (PDF Eq. 47):
+SE element Jacobian at `(ξ, η)` via Lagrange interpolation of nodal weighted-Jacobian
+values on `space` (PDF Eq. 47):
 
     Jᵉ(ξ, η) ≈ Σ_{p,q} Jᵉₚᵩ ϕₚ(ξ) ϕᵩ(η)
 
-where `Jᵉₚᵩ = WJ[p, q, 1, elem_idx] / (wₚ wᵩ)` is the unweighted Jacobian
-recovered from ClimaCore's `Spaces.weighted_jacobian` storage.
+where `Jᵉₚᵩ = WJ[p, q, 1, elem_idx] / (wₚ wᵩ)` is the unweighted Jacobian recovered from
+`Spaces.weighted_jacobian` storage.
 """
 function element_jacobian_at(space::ClimaCore.Spaces.AbstractSpectralElementSpace,
                              elem_idx::Int, ξ, η)
@@ -242,18 +226,15 @@ end
     accumulate_principled_b(manifold, space, elem_idx, intersection_polygon;
                             triangle_quad_degree) -> Matrix{Float64}
 
-Compute the principled `B(k, (e, i, j))` weights for a single source SE
-element `e = elem_idx` and a single destination polygon `intersection_polygon`
-(physical-space polygon, on the manifold). Returns an `Nq × Nq` matrix
-`B[i, j]` such that
+Principled `B(k, (e, i, j))` weights for one source SE element `e = elem_idx` and one
+destination physical-space polygon `intersection_polygon`. Returns an `Nq × Nq` matrix with
 
     B[i, j] ≈ ∫_{intersection_polygon} ϕᵢ(ξ) ϕⱼ(η) dA_phys       (PDF Eq. 48)
 
-The Jacobian factor in PDF Eq. 18 cancels via change of variables: if we
-integrate in physical space, `∫_{ref} ϕᵢϕⱼ Jᵉ dξ dη = ∫_{phys} ϕᵢ ϕⱼ dA`.
-Approach: fan-triangulate the polygon from its centroid, apply a barycentric
-Gauss rule on each triangle, evaluate the Lagrange basis at each quadrature
-point (using `inverse_element_map` to obtain `(ξ, η)`).
+The Jacobian factor in PDF Eq. 18 cancels under change of variables:
+`∫_{ref} ϕᵢϕⱼ Jᵉ dξ dη = ∫_{phys} ϕᵢ ϕⱼ dA`. Approach: fan-triangulate the polygon from its
+centroid, apply a barycentric Gauss rule per triangle, and evaluate the Lagrange basis at
+each quadrature point (`inverse_element_map` gives `(ξ, η)`).
 """
 function accumulate_principled_b(
     manifold::GOCore.Manifold,
@@ -362,8 +343,7 @@ end
 """
     se_field_to_vec(field)
 
-Convert a ClimaCore field to a flat vector of nodal values.
-Same ordering as [`se_node_positions`](@ref).
+Flat vector of a ClimaCore field's nodal values. Same ordering as [`se_node_positions`](@ref).
 """
 function se_field_to_vec(field)
     return flat_nodal_data(Fields.field_values(field))
@@ -509,16 +489,14 @@ end
 """
     compute_local_mass_matrix(space, elem_idx) -> Matrix{Float64}
 
-Build the dense `Nq² × Nq²` mass matrix for SE element `elem_idx`,
+Dense `Nq² × Nq²` mass matrix for SE element `elem_idx`,
 
     M^{e}_{(a,b),(i,j)} = ∫_{e} ϕₐ(ξ) ϕᵦ(η) ϕᵢ(ξ) ϕⱼ(η) Jᵉ(ξ,η) dξ dη ,
 
-with the row/col flattening following ClimaCore.Utilities.linear_ind(). 
-The integrand is a polynomial of bidegree `(2(Nq-1), 2(Nq-1))` in (ξ, η) 
-(the basis-function product) plus a polynomial of bidegree `(Nq-1, Nq-1)` 
-from the Lagrange interpolation of `Jᵉ` from the SE nodal values — total 
-bidegree `(3(Nq-1), 3(Nq-1))`. A GLL rule with `n` points per direction is 
-exact for polynomials of degree `2n - 1`, so we use `n = ceil((3Nq - 2)/2) + 1`.
+row/col flattening per `ClimaCore.Utilities.linear_ind()`. The integrand has bidegree
+`(2(Nq-1), 2(Nq-1))` (basis-function product) plus `(Nq-1, Nq-1)` (Lagrange-interpolated
+`Jᵉ`), total `(3(Nq-1), 3(Nq-1))`. A GLL rule with `n` points/direction is exact to degree
+`2n - 1`, so `n = ceil((3Nq - 2)/2) + 1`.
 """
 function compute_local_mass_matrix(
     space::ClimaCore.Spaces.AbstractSpectralElementSpace, elem_idx::Int,
@@ -677,13 +655,11 @@ end
 """
     fv_to_se_l2_projection(manifold, dst, src; ...)
 
-Per-element L2 projection FV → SE. Same `B` accumulation as the principled
-path, but the per-element rows are then multiplied by the *full* local mass
-matrix inverse `(M^{e})^{-1}` (rather than divided by the lumped diagonal
-`Wᵉᵢⱼ` as in PDF Eq. 30). This preserves constants exactly and is higher-
-order accurate: for any `f_src` that is exactly representable as a constant
-in each FV cell, the projection `f_dst = (M^{e})^{-1} (Bᵀ f_src)|_e` is the
-optimal L2 fit on the SE basis over element `e`.
+Per-element L2 projection FV → SE. Same `B` accumulation as the principled path, but
+per-element rows are multiplied by the *full* mass-matrix inverse `(M^{e})^{-1}` rather than
+divided by the lumped diagonal `Wᵉᵢⱼ` (cf. PDF Eq. 30). This preserves constants exactly and
+is higher-order accurate: `f_dst = (M^{e})^{-1} (Bᵀ f_src)|_e` is the optimal L2 fit on the
+SE basis over element `e`.
 """
 function fv_to_se_l2_projection(manifold, dst, src;
                                 threaded, triangle_quad_degree, kwargs...)

--- a/ext/ConservativeRegriddingClimaCoreExt.jl
+++ b/ext/ConservativeRegriddingClimaCoreExt.jl
@@ -347,8 +347,10 @@ function spherical_triangle_area(::GOCore.Spherical, p₁, p₂, p₃)
     q₁ = UnitSphericalPoint(p₁[1], p₁[2], p₁[3])
     q₂ = UnitSphericalPoint(p₂[1], p₂[2], p₂[3])
     q₃ = UnitSphericalPoint(p₃[1], p₃[2], p₃[3])
-    poly = GI.Polygon([GI.LinearRing(StaticArrays.SA[q₁, q₂, q₃, q₁])])
-    return GO.area(GO.Spherical(), poly)
+    poly = GI.Polygon(StaticArrays.SA[GI.LinearRing(StaticArrays.SA[q₁, q₂, q₃, q₁])])
+    # `::Float64` barrier: GO.area on a spherical polygon infers `Any`, which
+    # otherwise boxes every quadrature weight downstream in accumulate_principled_b.
+    return GO.area(GO.Spherical(), poly)::Float64
 end
 
 function spherical_triangle_area(::GOCore.Planar, p₁, p₂, p₃)

--- a/ext/ConservativeRegriddingClimaCoreExt.jl
+++ b/ext/ConservativeRegriddingClimaCoreExt.jl
@@ -6,8 +6,6 @@ using ConservativeRegridding: Trees
 import GeometryOpsCore as GOCore
 import GeometryOps as GO
 import GeoInterface as GI
-import SparseArrays
-import Extents
 
 using GeometryOps.UnitSpherical: UnitSphericalPoint
 using LinearAlgebra: normalize
@@ -388,23 +386,6 @@ function vec_to_se_field!(field, v::AbstractVector)
     return field
 end
 
-## Shared helpers for SE regridder construction
-
-"""
-    _get_candidate_pairs(manifold, se_tree, cell_tree, threaded)
-
-Get all candidate (SE element, cell) pairs for regridding.
-Uses a dual depth-first search to find all pairs of cells/elements that may intersect.
-"""
-function _get_candidate_pairs(manifold, se_tree, cell_tree, threaded)
-    _threaded = GOCore.booltype(threaded)
-    predicate_f = manifold isa GOCore.Spherical ?
-        GO.UnitSpherical._intersects : Extents.intersects
-    return ConservativeRegridding.get_all_candidate_pairs(
-        _threaded, predicate_f, se_tree, cell_tree
-    )
-end
-
 ## Regridder constructors
 
 const SESpaceOrField = Union{ClimaCore.Spaces.AbstractSpectralElementSpace, ClimaCore.Fields.Field}
@@ -422,6 +403,57 @@ function ConservativeRegridding.Regridder(
     return se_to_fv_principled(manifold, dst, se_space(src); threaded, triangle_quad_degree, kwargs...)
 end
 
+# SE → FV operator (`InPlace`, principled polygon-intersection, PDF Appendix A):
+# per (elem, cell) pair, push an Nq² block of B-weights per intersection polygon.
+struct SEToFVIntersectionOperator{M <: GOCore.Manifold, SP}
+    manifold::M
+    src_space::SP            # SE source space
+    Nq::Int
+    triangle_quad_degree::Int
+    N_fv::Int
+    N_nodes::Int
+end
+
+ConservativeRegridding.IntersectionReturnStyle(::SEToFVIntersectionOperator) = ConservativeRegridding.InPlace()
+ConservativeRegridding.output_matrix_size(op::SEToFVIntersectionOperator, ::Any, ::Any) = (op.N_fv, op.N_nodes)
+
+function (op::SEToFVIntersectionOperator)(rows, cols, vals, (elem, cell), src_tree, dst_tree)
+    elem_poly = Trees.getcell(src_tree, elem)
+    cell_poly = Trees.getcell(dst_tree, cell)
+
+    intersection_result = if op.manifold isa GOCore.Spherical
+        GO.intersection(GO.ConvexConvexSutherlandHodgman(op.manifold),
+                        elem_poly, cell_poly; target = GI.PolygonTrait())
+    else
+        GO.intersection(GO.FosterHormannClipping(GO.Planar()),
+                        elem_poly, cell_poly; target = GI.PolygonTrait())
+    end
+
+    # GO.intersection may return a single Polygon, a Vector{Polygon}, or
+    # nothing for an empty intersection. Normalize to an iterable.
+    intersection_polys = if isnothing(intersection_result)
+        ()
+    elseif intersection_result isa AbstractVector
+        intersection_result
+    else
+        (intersection_result,)   # single Polygon
+    end
+
+    for ipoly in intersection_polys
+        B = accumulate_principled_b(op.manifold, op.src_space, elem, ipoly;
+                                    triangle_quad_degree = op.triangle_quad_degree)
+        offset = (elem - 1) * op.Nq^2
+        for j in 1:op.Nq, i in 1:op.Nq
+            Bᵢⱼ = B[i, j]
+            Bᵢⱼ == 0 && continue
+            push!(rows, cell)
+            push!(cols, offset + linear_ind((op.Nq, op.Nq), (i, j)))
+            push!(vals, Bᵢⱼ)
+        end
+    end
+    return nothing
+end
+
 function se_to_fv_principled(manifold, dst, src; threaded, triangle_quad_degree, kwargs...)
     se_tree = Trees.treeify(manifold, src)
     fv_tree = Trees.treeify(manifold, dst)
@@ -433,49 +465,16 @@ function se_to_fv_principled(manifold, dst, src; threaded, triangle_quad_degree,
 
     triangle_quad_degree = something(triangle_quad_degree, 2 * (Nq - 1))
 
-    candidate_pairs = _get_candidate_pairs(manifold, se_tree, fv_tree, threaded)
+    # Assemble the N_fv × N_nodes matrix via the shared parallel driver: src = SE
+    # elements, dst = FV cells, so candidate pairs are uniformly (elem, cell).
+    op = SEToFVIntersectionOperator(manifold, src, Nq, triangle_quad_degree, N_fv, N_nodes)
+    # Extra kwargs (e.g. `normalize`) are absorbed by the signature and not forwarded;
+    # `intersection_areas` only accepts assembly kwargs.
+    intersections = ConservativeRegridding.intersection_areas(
+        manifold, GOCore.booltype(threaded), fv_tree, se_tree;
+        intersection_operator = op,
+    )
 
-    rows = Int[]
-    cols = Int[]
-    vals = Float64[]
-
-    for (elem_idx, cell_idx) in candidate_pairs
-        elem_poly = Trees.getcell(se_tree, elem_idx)
-        cell_poly = Trees.getcell(fv_tree, cell_idx)
-
-        intersection_result = if manifold isa GOCore.Spherical
-            GO.intersection(GO.ConvexConvexSutherlandHodgman(manifold),
-                            elem_poly, cell_poly; target = GI.PolygonTrait())
-        else
-            GO.intersection(GO.FosterHormannClipping(GO.Planar()),
-                            elem_poly, cell_poly; target = GI.PolygonTrait())
-        end
-
-        # GO.intersection may return a single Polygon, a Vector{Polygon}, or
-        # nothing for an empty intersection. Normalize to an iterable.
-        intersection_polys = if intersection_result === nothing
-            ()
-        elseif intersection_result isa AbstractVector
-            intersection_result
-        else
-            (intersection_result,)   # single Polygon
-        end
-
-        for ipoly in intersection_polys
-            B = accumulate_principled_b(manifold, src, elem_idx, ipoly;
-                                        triangle_quad_degree)
-            offset = (elem_idx - 1) * Nq^2
-            for j in 1:Nq, i in 1:Nq
-                Bᵢⱼ = B[i, j]
-                Bᵢⱼ == 0 && continue
-                push!(rows, cell_idx)
-                push!(cols, offset + linear_ind((Nq, Nq), (i, j)))
-                push!(vals, Bᵢⱼ)
-            end
-        end
-    end
-
-    intersections = SparseArrays.sparse(rows, cols, vals, N_fv, N_nodes)
     dst_areas = ConservativeRegridding.areas(manifold, dst, fv_tree)
     src_areas = Vector{eltype(dst_areas)}(se_node_weights(src))
 
@@ -559,6 +558,120 @@ function compute_local_mass_matrix(
     return M
 end
 
+# FV → SE operator (`InPlace`, per-element L2 projection). The per-element mass-matrix
+# solve needs all of an element's cells at once, so `work_items` makes the element
+# (not the candidate pair) the unit of work. Assembled matrix is N_nodes × N_fv.
+struct FVToSEIntersectionOperator{M <: GOCore.Manifold, SP}
+    manifold::M
+    dst_space::SP            # SE destination space
+    Nq::Int
+    triangle_quad_degree::Int
+    Nh::Int
+    N_nodes::Int
+    N_fv::Int
+end
+
+ConservativeRegridding.IntersectionReturnStyle(::FVToSEIntersectionOperator) = ConservativeRegridding.InPlace()
+ConservativeRegridding.output_matrix_size(op::FVToSEIntersectionOperator, ::Any, ::Any) = (op.N_nodes, op.N_fv)
+
+# Group (elem, cell) pairs into one (elem, cells) item per non-empty element, preserving
+# candidate-pair order so serial assembly matches the old per-element loop.
+function ConservativeRegridding.work_items(op::FVToSEIntersectionOperator, candidate_pairs)
+    cells_by_elem = [Int[] for _ in 1:op.Nh]
+    for (elem, cell) in candidate_pairs
+        push!(cells_by_elem[elem], cell)
+    end
+    return [(e, cells_by_elem[e]) for e in 1:op.Nh if !isempty(cells_by_elem[e])]
+end
+
+function (op::FVToSEIntersectionOperator)(rows, cols, vals, (elem, cells), src_tree, dst_tree)
+    Nq = op.Nq
+    elem_poly = Trees.getcell(src_tree, elem)
+
+    # Phase 1: accumulate B for this element, keyed by destination cell, value = Nq² vector.
+    d = Dict{Int, Vector{Float64}}()
+    for cell in cells
+        cell_poly = Trees.getcell(dst_tree, cell)
+
+        intersection_result = if op.manifold isa GOCore.Spherical
+            GO.intersection(GO.ConvexConvexSutherlandHodgman(op.manifold),
+                            elem_poly, cell_poly; target = GI.PolygonTrait())
+        else
+            GO.intersection(GO.FosterHormannClipping(GO.Planar()),
+                            elem_poly, cell_poly; target = GI.PolygonTrait())
+        end
+
+        intersection_polys = if isnothing(intersection_result)
+            ()
+        elseif intersection_result isa AbstractVector
+            intersection_result
+        else
+            (intersection_result,)
+        end
+
+        for ipoly in intersection_polys
+            B = accumulate_principled_b(op.manifold, op.dst_space, elem, ipoly;
+                                        triangle_quad_degree = op.triangle_quad_degree)
+            v = get!(d, cell) do
+                zeros(Nq^2)
+            end
+            for jb in 1:Nq, ja in 1:Nq
+                Bᵢⱼ = B[ja, jb]
+                Bᵢⱼ == 0 && continue
+                v[linear_ind((Nq, Nq), (ja, jb))] += Bᵢⱼ
+            end
+        end
+    end
+    isempty(d) && return nothing
+
+    # Phase 2: solve Mᵉ f_dst = b for each cell column, push the COO block.
+    #
+    # Mᵉ comes from tensor-product GLL on the reference square but B from fan
+    # triangulation on the great-circle physical polygon, so the two
+    # quadratures integrate over slightly different domains. We rescale each
+    # row of Mᵉ so that its row sum equals the column-sum of B for that
+    # element — what Mᵉ·1 must equal by partition of unity if both sides used
+    # identical quadrature. This forces exact constant preservation.
+    Mᵉ = compute_local_mass_matrix(op.dst_space, elem)
+
+    b_full = zeros(Nq^2)
+    for b_vec in values(d)
+        b_full .+= b_vec
+    end
+
+    # If b_full == 0 it means we are hitting regions with no
+    # overlap (for example regridding a tripolar grid that ends
+    # at 80ᵒ S onto a SE grid that covers the sphere).
+    # We cover for those cases.
+    covered = findall(!=(0), b_full)
+    isempty(covered) && return nothing
+    Mᶜ = Mᵉ[covered, covered]
+
+    row_sums = vec(sum(Mᶜ; dims=2))
+    for (rc, r) in enumerate(covered)
+        row_sums[rc] == 0 && continue
+        scale = b_full[r] / row_sums[rc]
+        @inbounds for c in axes(Mᶜ, 2)
+            Mᶜ[rc, c] *= scale
+        end
+    end
+
+    Mᶜ_inv = inv(Mᶜ)
+
+    offset = (elem - 1) * Nq^2
+    for (cell, b_vec) in d
+        new_col = Mᶜ_inv * b_vec[covered]
+        for (rc, r) in enumerate(covered)
+            val = new_col[rc]
+            val == 0 && continue
+            push!(rows, offset + r)
+            push!(cols, cell)
+            push!(vals, val)
+        end
+    end
+    return nothing
+end
+
 """
     fv_to_se_l2_projection(manifold, dst, src; ...)
 
@@ -582,102 +695,17 @@ function fv_to_se_l2_projection(manifold, dst, src;
 
     triangle_quad_degree = something(triangle_quad_degree, 2 * (Nq - 1))
 
-    candidate_pairs = _get_candidate_pairs(manifold, se_tree, fv_tree, threaded)
+    # Assemble the N_nodes × N_fv matrix via the shared parallel driver: src = SE
+    # elements, dst = FV cells, with `work_items` regrouping pairs by element so the
+    # per-element mass-matrix solve sees all of an element's cells at once.
+    op = FVToSEIntersectionOperator(manifold, dst, Nq, triangle_quad_degree, Nh, N_nodes, N_fv)
+    # Extra kwargs (e.g. `normalize`) are absorbed by the signature and not forwarded;
+    # `intersection_areas` only accepts assembly kwargs.
+    intersections = ConservativeRegridding.intersection_areas(
+        manifold, GOCore.booltype(threaded), fv_tree, se_tree;
+        intersection_operator = op,
+    )
 
-    # Accumulate B per element, keyed by destination cell, value = Nq² vector.
-    elem_b_dicts = [Dict{Int, Vector{Float64}}() for _ in 1:Nh]
-
-    for (elem_idx, cell_idx) in candidate_pairs
-        elem_poly = Trees.getcell(se_tree, elem_idx)
-        cell_poly = Trees.getcell(fv_tree, cell_idx)
-
-        intersection_result = if manifold isa GOCore.Spherical
-            GO.intersection(GO.ConvexConvexSutherlandHodgman(manifold),
-                            elem_poly, cell_poly; target = GI.PolygonTrait())
-        else
-            GO.intersection(GO.FosterHormannClipping(GO.Planar()),
-                            elem_poly, cell_poly; target = GI.PolygonTrait())
-        end
-
-        intersection_polys = if intersection_result === nothing
-            ()
-        elseif intersection_result isa AbstractVector
-            intersection_result
-        else
-            (intersection_result,)
-        end
-
-        for ipoly in intersection_polys
-            B = accumulate_principled_b(manifold, dst, elem_idx, ipoly;
-                                        triangle_quad_degree)
-            d = elem_b_dicts[elem_idx]
-            v = get!(d, cell_idx) do
-                zeros(Nq^2)
-            end
-            for jb in 1:Nq, ja in 1:Nq
-                Bᵢⱼ = B[ja, jb]
-                Bᵢⱼ == 0 && continue
-                v[linear_ind((Nq, Nq), (ja, jb))] += Bᵢⱼ
-            end
-        end
-    end
-
-    # For each element, solve Mᵉ f_dst = b for each cell column, emit COO.
-    #
-    # Mᵉ comes from tensor-product GLL on the reference square but B from fan
-    # triangulation on the great-circle physical polygon, so the two
-    # quadratures integrate over slightly different domains. We rescale each
-    # row of Mᵉ so that its row sum equals the column-sum of B for that
-    # element — what Mᵉ·1 must equal by partition of unity if both sides used
-    # identical quadrature. This forces exact constant preservation.
-    rows = Int[]
-    cols = Int[]
-    vals = Float64[]
-
-    for elem_idx in 1:Nh
-        d = elem_b_dicts[elem_idx]
-        isempty(d) && continue
-
-        Mᵉ = compute_local_mass_matrix(dst, elem_idx)
-
-        b_full = zeros(Nq^2)
-        for b_vec in values(d)
-            b_full .+= b_vec
-        end
-
-        # If b_full == 0 it means we are hitting regions with no 
-        # overlap (for example a regridding a tripolar grid than ends
-        # at 80ᵒ S onto a SE grid that covers the sphere).
-        # We cover for those cases.
-        covered = findall(!=(0), b_full)
-        isempty(covered) && continue
-        Mᶜ = Mᵉ[covered, covered]
-
-        row_sums = vec(sum(Mᶜ; dims=2))
-        for (rc, r) in enumerate(covered)
-            row_sums[rc] == 0 && continue
-            scale = b_full[r] / row_sums[rc]
-            @inbounds for c in axes(Mᶜ, 2)
-                Mᶜ[rc, c] *= scale
-            end
-        end
-
-        Mᶜ_inv = inv(Mᶜ)
-
-        offset = (elem_idx - 1) * Nq^2
-        for (cell_idx, b_vec) in d
-            new_col = Mᶜ_inv * b_vec[covered]
-            for (rc, r) in enumerate(covered)
-                v = new_col[rc]
-                v == 0 && continue
-                push!(rows, offset + r)
-                push!(cols, cell_idx)
-                push!(vals, v)
-            end
-        end
-    end
-
-    intersections = SparseArrays.sparse(rows, cols, vals, N_nodes, N_fv)
     src_areas = ConservativeRegridding.areas(manifold, src, fv_tree)
     # inv-mass already baked into `intersections`; ones make pipeline normalize a no-op
     dst_areas = ones(N_nodes)

--- a/src/ConservativeRegridding.jl
+++ b/src/ConservativeRegridding.jl
@@ -40,6 +40,10 @@ include("regridder/intersection_areas.jl")
 @public Regridder, regrid, regrid!
 @public areas
 @public AbstractDimensionalSlicer, NDSliceLoop, slice_views, extract_source_arraylike, extract_dest_arraylike
+# Intersection-operator assembly interface (operators can plug into `intersection_areas`)
+@public intersection_areas, DefaultIntersectionOperator
+@public IntersectionReturnStyle, OutOfPlaceSingleResult, InPlace
+@public work_items, output_matrix_size
 
 """
     save_esmf_weights(path, regridder;

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -1,35 +1,85 @@
 import GeometryOps as GO
 using GeometryOps: SpatialTreeInterface as STI
 
-function compute_intersection_areas(
-        manifold::M, 
-        intersection_operator::F,
-        dst_tree::D, 
-        src_tree::S, 
-        idxs::AbstractVector{Tuple{Int, Int}}, 
-    ) where {M <: Manifold, F, D, S}
+# Intersection-operator interface: the operator drives assembly via one trait
+# (`IntersectionReturnStyle`) + two hooks (`work_items`, `output_matrix_size`),
+# each with a default reproducing the built-in area computation.
 
-    ret_i1 = Int[]
-    ret_i2 = Int[]
-    ret_area = Float64[]
-    sizehint!(ret_i1, length(idxs))
-    sizehint!(ret_i2, length(idxs))
-    sizehint!(ret_area, length(idxs))
+"""
+    abstract type IntersectionReturnStyle
 
-    # Loop through all candidate pairs and attempt intersection.
-    for (i1, i2) in idxs
-        p1 = Trees.getcell(src_tree, i1)
-        p2 = Trees.getcell(dst_tree, i2)
-        area_of_intersection = intersection_operator(p1, p2)
-        if area_of_intersection > 0
-            push!(ret_i1, i1)
-            push!(ret_i2, i2)
-            push!(ret_area, area_of_intersection)
-        end
-    end
+Trait describing how an intersection operator delivers its contribution for a
+single unit of work during sparse-matrix assembly.  The trait is resolved once,
+at the top of [`intersection_areas`](@ref) via the accessor
+`IntersectionReturnStyle(op)`, and the resulting value is threaded through the
+parallel assembly so the trait lookup never happens in the hot loop.
 
-    return ret_i1, ret_i2, ret_area
-end
+Subtypes:
+- [`OutOfPlaceSingleResult`](@ref): the kernel is `op(src_cell, dst_cell) -> area`
+  and the driver stores the COO triplet.
+- [`InPlace`](@ref): the kernel is
+  `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` and pushes its own
+  COO contributions.
+
+The default accessor returns [`OutOfPlaceSingleResult`](@ref), so any operator
+that does not override it behaves like [`DefaultIntersectionOperator`](@ref).
+"""
+abstract type IntersectionReturnStyle end
+
+"""
+    OutOfPlaceSingleResult <: IntersectionReturnStyle
+
+Return style for operators that compute one scalar per candidate pair.  The
+kernel is `op(src_cell, dst_cell) -> area::Real`; the driver stores the COO
+triplet `(dst_index, src_index, area)` whenever `area > 0`.  This is the default
+style and the one used by [`DefaultIntersectionOperator`](@ref).
+"""
+struct OutOfPlaceSingleResult <: IntersectionReturnStyle end
+
+"""
+    InPlace <: IntersectionReturnStyle
+
+Return style for operators that push a block of COO contributions per work item.
+The kernel is `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` and is
+responsible for `push!`ing onto `rows`/`cols`/`vals` itself.  Used by
+block-emitting operators such as the ClimaCore spectral-element assemblers.
+"""
+struct InPlace <: IntersectionReturnStyle end
+
+"""
+    IntersectionReturnStyle(op) -> IntersectionReturnStyle
+
+Return the [`IntersectionReturnStyle`](@ref) of intersection operator `op`.
+Defaults to [`OutOfPlaceSingleResult`](@ref); operators that assemble blocks in
+place override this to return [`InPlace`](@ref).
+"""
+IntersectionReturnStyle(::Any) = OutOfPlaceSingleResult()
+
+"""
+    work_items(op, candidate_pairs) -> items
+
+Map the candidate `(src_index, dst_index)` pairs to the collection of work units
+that the parallel assembly iterates over.  Each item is handed to the operator:
+destructured as `(src_index, dst_index)` for [`OutOfPlaceSingleResult`](@ref), or
+passed through verbatim for [`InPlace`](@ref).
+
+Defaults to one work unit per candidate pair.  Override it to change the parallel
+granularity — e.g. to group all of an element's candidate cells into a single
+work unit.
+"""
+work_items(::Any, candidate_pairs) = candidate_pairs
+
+"""
+    output_matrix_size(op, src_tree, dst_tree) -> (nrows, ncols)
+
+Return the `(nrows, ncols)` shape of the sparse matrix that
+[`intersection_areas`](@ref) assembles for operator `op`.  Defaults to
+`(prod(ncells(dst_tree)), prod(ncells(src_tree)))` — destination cells as rows,
+source cells as columns.  Operators whose row/column counts differ from the cell
+counts (e.g. spectral-element node counts) override this.
+"""
+output_matrix_size(::Any, src_tree, dst_tree) =
+    (prod(Trees.ncells(dst_tree)), prod(Trees.ncells(src_tree)))
 
 # If the root tree is a `WithParallelizePolicy`, route the dual-DFS's
 # `(node, extent)` query through the user policy; otherwise fall back to the
@@ -64,70 +114,100 @@ function get_all_candidate_pairs(threaded::False, predicate_f::F, src_tree::T1, 
     return candidate_idxs
 end
 
-function intersection_areas(
-        manifold::M, threaded::True, dst_tree::T1, src_tree::T2;
-        intersection_operator::F = DefaultIntersectionOperator(manifold),
-        npartitions::Int = Threads.nthreads() * 4,
-        progress = false,
-    ) where {M <: Manifold,F, T1, T2}
+# Shared parallel COO assembly. `style` (the resolved `IntersectionReturnStyle`)
+# is threaded through so the trait is never looked up in the hot loop.
 
-    predicate_f = if M <: Spherical
-        GO.UnitSpherical._intersects
-    else
-        Extents.intersects
+# Run the operator for one work item and store its COO contribution(s).
+@inline function _run_and_store!(::OutOfPlaceSingleResult, op, rows, cols, vals, (i1, i2), src_tree, dst_tree)
+    p1 = Trees.getcell(src_tree, i1)
+    p2 = Trees.getcell(dst_tree, i2)
+    area_of_intersection = op(p1, p2)
+    if area_of_intersection > 0
+        push!(rows, i2)   # row = destination index
+        push!(cols, i1)   # col = source index
+        push!(vals, area_of_intersection)
     end
-    # TODO: Threaded dual dfs via chunking.
-    # For now this is just serial, and is the big bottleneck for larger grids.
-    # First, run the dual depth first search to get all candidate pairs of 
-    # cells that may intersect.
-    candidate_idxs = get_all_candidate_pairs(threaded, predicate_f, src_tree, dst_tree)
+    return nothing
+end
 
-    # Then, partition the list of indices to check,
-    partitions = ChunkSplitters.chunks(candidate_idxs; n = npartitions)
+@inline function _run_and_store!(::InPlace, op, rows, cols, vals, item, src_tree, dst_tree)
+    op(rows, cols, vals, item, src_tree, dst_tree)   # the operator stores in place
+    return nothing
+end
+
+# One chunk of work items → its COO triplets. `style` is passed in, not re-resolved.
+function _assemble_chunk(style, op, items, src_tree, dst_tree)
+    rows = Int[]
+    cols = Int[]
+    vals = Float64[]
+    for item in items
+        _run_and_store!(style, op, rows, cols, vals, item, src_tree, dst_tree)
+    end
+    return rows, cols, vals
+end
+
+# `True` chunks/spawns, `False` runs one chunk. `$`-interpolation keeps the
+# spawned tasks type-stable (concrete `style`/`op`/trees, no boxing).
+function _parallel_coo(style, op, items, src_tree, dst_tree, ::True; npartitions, progress)
+    # Partition the list of work items,
+    partitions = ChunkSplitters.chunks(items; n = npartitions)
     if progress
         progress_meter = ProgressMeter.Progress(length(partitions); desc = "Computing intersection areas")
     end
-    # and compute the intersection areas for each partition in parallel.
+    # and assemble the COO triplets for each partition in parallel.
     # This is a bit oversubscribed though I guess.  But Julia's dynamic
     # scheduler should handle it fine.
     result_tasks = [
         StableTasks.@spawn begin
-            ret = compute_intersection_areas(
-                $manifold, 
-                $intersection_operator,
-                $dst_tree, 
-                $src_tree, 
-                partition, 
-            ) 
+            ret = _assemble_chunk($style, $op, partition, $src_tree, $dst_tree)
             $(progress ? :(ProgressMeter.next!(progress_meter)) : :())
             ret
         end
         for partition in partitions
     ]
-    
     # Fetch the results of `result_tasks`
     all_results = map(fetch, result_tasks)
-    # Concatenate the results into single vectors
-    i1s = reduce(vcat, getindex.(all_results, 1))
-    i2s = reduce(vcat, getindex.(all_results, 2))
-    areas = reduce(vcat, getindex.(all_results, 3))
-    # Assemble a sparse matrix from the results.
-    return SparseArrays.sparse(
-        i2s, 
-        i1s, 
-        areas, 
-        prod(Trees.ncells(dst_tree)), 
-        prod(Trees.ncells(src_tree)),
-    )
+    # Concatenate the per-chunk COO vectors into single vectors, in partition order.
+    rows = reduce(vcat, getindex.(all_results, 1))
+    cols = reduce(vcat, getindex.(all_results, 2))
+    vals = reduce(vcat, getindex.(all_results, 3))
+    return rows, cols, vals
 end
 
+_parallel_coo(style, op, items, src_tree, dst_tree, ::False; kwargs...) =
+    _assemble_chunk(style, op, items, src_tree, dst_tree)
 
+"""
+    intersection_areas(manifold, threaded, dst_tree, src_tree;
+                       intersection_operator = DefaultIntersectionOperator(manifold),
+                       npartitions = Threads.nthreads() * 4, progress = false)
+
+Assemble the sparse intersection matrix between `src_tree` and `dst_tree` on
+`manifold`.
+
+This is the lower-level assembly entry that intersection operators plug into;
+most users go through [`Regridder`](@ref)`(…; intersection_operator = …)`, which
+calls this.
+
+The build is driven by three dispatched seams on `intersection_operator`, each
+with a default reproducing the built-in area computation:
+- [`IntersectionReturnStyle`](@ref)`(op)` — how each work item's contribution is stored.
+- [`work_items`](@ref)`(op, candidate_pairs)` — the units of work the parallel loop iterates.
+- [`output_matrix_size`](@ref)`(op, src_tree, dst_tree)` — the `(nrows, ncols)` matrix shape.
+
+`threaded` is a `GeometryOpsCore.BoolsAsTypes` (`True()`/`False()`); pass
+`booltype(::Bool)` to convert.  When threaded, candidate work items are
+partitioned into `npartitions` chunks assembled on separate tasks.
+"""
 function intersection_areas(
-        manifold::M, threaded::False, dst_tree::T1, src_tree::T2;
-        intersection_operator::F = DefaultIntersectionOperator(manifold),
+        manifold::M, threaded::BoolsAsTypes, dst_tree, src_tree;
+        intersection_operator = DefaultIntersectionOperator(manifold),
         npartitions::Int = Threads.nthreads() * 4,
         progress = false,
-    ) where {M <: Manifold,F, T1, T2}
+    ) where {M <: Manifold}
+
+    # Resolve the return-style trait once, here, and thread `style` through everything.
+    style = IntersectionReturnStyle(intersection_operator)
 
     predicate_f = if M <: Spherical
         GO.UnitSpherical._intersects
@@ -135,24 +215,17 @@ function intersection_areas(
         Extents.intersects
     end
 
-    candidate_idxs = get_all_candidate_pairs(threaded, predicate_f, src_tree, dst_tree)
+    # First, run the dual depth first search to get all candidate pairs of
+    # cells that may intersect.
+    candidate_pairs = get_all_candidate_pairs(threaded, predicate_f, src_tree, dst_tree)
 
-    # if progress
-    #     progress_meter = ProgressMeter.Progress(length(candidate_idxs); desc = "Computing intersection areas")
-    # end
-    i1s, i2s, areas = compute_intersection_areas(
-        manifold, 
-        intersection_operator,
-        dst_tree, 
-        src_tree, 
-        candidate_idxs
-    ) 
-    # Assemble a sparse matrix from the results.
-    return SparseArrays.sparse(
-        i2s, 
-        i1s, 
-        areas, 
-        prod(Trees.ncells(dst_tree)), 
-        prod(Trees.ncells(src_tree)),
+    # Map candidate pairs → work units (default: one pair per unit), assemble the
+    # COO triplets (in parallel or serially), and build the sparse matrix.
+    items = work_items(intersection_operator, candidate_pairs)
+    nrows, ncols = output_matrix_size(intersection_operator, src_tree, dst_tree)
+    rows, cols, vals = _parallel_coo(
+        style, intersection_operator, items, src_tree, dst_tree, threaded;
+        npartitions, progress,
     )
+    return SparseArrays.sparse(rows, cols, vals, nrows, ncols)
 end

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -8,75 +8,65 @@ using GeometryOps: SpatialTreeInterface as STI
 """
     abstract type IntersectionReturnStyle
 
-Trait describing how an intersection operator delivers its contribution for a
-single unit of work during sparse-matrix assembly.  The trait is resolved once,
-at the top of [`intersection_areas`](@ref) via the accessor
-`IntersectionReturnStyle(op)`, and the resulting value is threaded through the
-parallel assembly so the trait lookup never happens in the hot loop.
+Trait for how an intersection operator delivers its contribution per work item
+during sparse-matrix assembly. Resolved once via `IntersectionReturnStyle(op)`
+at the top of [`intersection_areas`](@ref) and threaded through the parallel
+assembly, so the lookup never happens in the hot loop.
 
 Subtypes:
-- [`OutOfPlaceSingleResult`](@ref): the kernel is `op(src_cell, dst_cell) -> area`
-  and the driver stores the COO triplet.
-- [`InPlace`](@ref): the kernel is
-  `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` and pushes its own
-  COO contributions.
+- [`OutOfPlaceSingleResult`](@ref): kernel `op(src_cell, dst_cell) -> area`; driver stores the COO triplet.
+- [`InPlace`](@ref): kernel `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` pushes its own COO.
 
-The default accessor returns [`OutOfPlaceSingleResult`](@ref), so any operator
-that does not override it behaves like [`DefaultIntersectionOperator`](@ref).
+Defaults to [`OutOfPlaceSingleResult`](@ref), matching [`DefaultIntersectionOperator`](@ref).
 """
 abstract type IntersectionReturnStyle end
 
 """
     OutOfPlaceSingleResult <: IntersectionReturnStyle
 
-Return style for operators that compute one scalar per candidate pair.  The
-kernel is `op(src_cell, dst_cell) -> area::Real`; the driver stores the COO
-triplet `(dst_index, src_index, area)` whenever `area > 0`.  This is the default
-style and the one used by [`DefaultIntersectionOperator`](@ref).
+One scalar per candidate pair. Kernel `op(src_cell, dst_cell) -> area::Real`; the
+driver stores the COO triplet `(dst_index, src_index, area)` when `area > 0`.
+Default style, used by [`DefaultIntersectionOperator`](@ref).
 """
 struct OutOfPlaceSingleResult <: IntersectionReturnStyle end
 
 """
     InPlace <: IntersectionReturnStyle
 
-Return style for operators that push a block of COO contributions per work item.
-The kernel is `op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` and is
-responsible for `push!`ing onto `rows`/`cols`/`vals` itself.  Used by
-block-emitting operators such as the ClimaCore spectral-element assemblers.
+A block of COO contributions per work item. Kernel
+`op(rows, cols, vals, item, src_tree, dst_tree) -> nothing` `push!`es onto
+`rows`/`cols`/`vals` itself. Used by block-emitting operators such as the
+ClimaCore spectral-element assemblers.
 """
 struct InPlace <: IntersectionReturnStyle end
 
 """
     IntersectionReturnStyle(op) -> IntersectionReturnStyle
 
-Return the [`IntersectionReturnStyle`](@ref) of intersection operator `op`.
-Defaults to [`OutOfPlaceSingleResult`](@ref); operators that assemble blocks in
-place override this to return [`InPlace`](@ref).
+Return the [`IntersectionReturnStyle`](@ref) of operator `op`. Defaults to
+[`OutOfPlaceSingleResult`](@ref); block-assembling operators override to [`InPlace`](@ref).
 """
 IntersectionReturnStyle(::Any) = OutOfPlaceSingleResult()
 
 """
     work_items(op, candidate_pairs) -> items
 
-Map the candidate `(src_index, dst_index)` pairs to the collection of work units
-that the parallel assembly iterates over.  Each item is handed to the operator:
-destructured as `(src_index, dst_index)` for [`OutOfPlaceSingleResult`](@ref), or
-passed through verbatim for [`InPlace`](@ref).
+Map candidate `(src_index, dst_index)` pairs to the work units the parallel
+assembly iterates. Each item is destructured as `(src_index, dst_index)` for
+[`OutOfPlaceSingleResult`](@ref) or passed through verbatim for [`InPlace`](@ref).
 
-Defaults to one work unit per candidate pair.  Override it to change the parallel
-granularity — e.g. to group all of an element's candidate cells into a single
-work unit.
+Defaults to one unit per candidate pair. Override to change parallel granularity —
+e.g. to group all of an element's candidate cells into one unit.
 """
 work_items(::Any, candidate_pairs) = candidate_pairs
 
 """
     output_matrix_size(op, src_tree, dst_tree) -> (nrows, ncols)
 
-Return the `(nrows, ncols)` shape of the sparse matrix that
-[`intersection_areas`](@ref) assembles for operator `op`.  Defaults to
-`(prod(ncells(dst_tree)), prod(ncells(src_tree)))` — destination cells as rows,
-source cells as columns.  Operators whose row/column counts differ from the cell
-counts (e.g. spectral-element node counts) override this.
+Shape of the sparse matrix [`intersection_areas`](@ref) assembles for `op`.
+Defaults to `(prod(ncells(dst_tree)), prod(ncells(src_tree)))` — dst cells as
+rows, src cells as columns. Operators whose counts differ from cell counts
+(e.g. spectral-element node counts) override this.
 """
 output_matrix_size(::Any, src_tree, dst_tree) =
     (prod(Trees.ncells(dst_tree)), prod(Trees.ncells(src_tree)))
@@ -183,21 +173,18 @@ _parallel_coo(style, op, items, src_tree, dst_tree, ::False; kwargs...) =
                        npartitions = Threads.nthreads() * 4, progress = false)
 
 Assemble the sparse intersection matrix between `src_tree` and `dst_tree` on
-`manifold`.
+`manifold`. Lower-level assembly entry that intersection operators plug into;
+most users go through [`Regridder`](@ref)`(…; intersection_operator = …)`.
 
-This is the lower-level assembly entry that intersection operators plug into;
-most users go through [`Regridder`](@ref)`(…; intersection_operator = …)`, which
-calls this.
-
-The build is driven by three dispatched seams on `intersection_operator`, each
-with a default reproducing the built-in area computation:
+Driven by three dispatched seams on `intersection_operator`, each defaulting to
+the built-in area computation:
 - [`IntersectionReturnStyle`](@ref)`(op)` — how each work item's contribution is stored.
-- [`work_items`](@ref)`(op, candidate_pairs)` — the units of work the parallel loop iterates.
-- [`output_matrix_size`](@ref)`(op, src_tree, dst_tree)` — the `(nrows, ncols)` matrix shape.
+- [`work_items`](@ref)`(op, candidate_pairs)` — the units of work iterated.
+- [`output_matrix_size`](@ref)`(op, src_tree, dst_tree)` — the `(nrows, ncols)` shape.
 
-`threaded` is a `GeometryOpsCore.BoolsAsTypes` (`True()`/`False()`); pass
-`booltype(::Bool)` to convert.  When threaded, candidate work items are
-partitioned into `npartitions` chunks assembled on separate tasks.
+`threaded` is a `GeometryOpsCore.BoolsAsTypes` (`True()`/`False()`; convert via
+`booltype(::Bool)`). When threaded, work items are partitioned into `npartitions`
+chunks assembled on separate tasks.
 """
 function intersection_areas(
         manifold::M, threaded::BoolsAsTypes, dst_tree, src_tree;

--- a/test/usecases/climacore.jl
+++ b/test/usecases/climacore.jl
@@ -192,6 +192,27 @@ end
     @test isapprox(sum(fv_vals .* fv_areas), sum(src_field); rtol=1e-2, atol=10.0)
 end
 
+@testset "Threaded vs serial assembly is identical (SE↔FV)" begin
+    # Parallel and serial assembly must produce identical matrices: there are no
+    # cross-pair duplicate (row,col) entries, so chunking can't change any sum. A
+    # discrepancy signals a data race or ordering bug. Tested on regular + Gilbert.
+    coarse_latlon = LatitudeLongitudeGrid(
+        size=(72, 36, 1), longitude=(0, 360), latitude=(-90, 90),
+        z=(0, 1), radius=GO.Spherical().radius,
+    )
+    for use_sfc in (false, true)
+        space = make_cubedsphere_space(; h_elem=8, n_quad_points=4, use_sfc=use_sfc)
+
+        se_to_fv_threaded = ConservativeRegridding.Regridder(coarse_latlon, space; threaded=true)
+        se_to_fv_serial   = ConservativeRegridding.Regridder(coarse_latlon, space; threaded=false)
+        @test se_to_fv_threaded.intersections == se_to_fv_serial.intersections
+
+        fv_to_se_threaded = ConservativeRegridding.Regridder(space, coarse_latlon; threaded=true)
+        fv_to_se_serial   = ConservativeRegridding.Regridder(space, coarse_latlon; threaded=false)
+        @test fv_to_se_threaded.intersections == fv_to_se_serial.intersections
+    end
+end
+
 @testset "Oceananigans TripolarGrid to ClimaCore cubed sphere (default folding)" begin
     tripolar_grid = TripolarGrid(size=(360, 180, 1))
     space = CommonSpaces.CubedSphereSpace(;


### PR DESCRIPTION
Adds a new interface for the intersection operator, so that ClimaCore only needs to define its intersection operator, not the full sparse matrix assembly.

Also adds some benchmarks for the ClimaCore regridder construction, as well as performance optimisation / improvements there.