### PR TITLE
Benchmark suite: grid-scaling + ConservativeRegridding-vs-XESMF construction, with PR-vs-base CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,103 @@
+name: Benchmarks
+
+# Regridder-construction benchmarks, modeled on Makie's PR-vs-base benchmark CI: the benchmark
+# DRIVER always comes from the PR checkout, and only the ConservativeRegridding package is swapped
+# between the PR ref and the base ref (each run in an isolated subprocess). Results are rendered to
+# graphs that are pushed to an orphan `benchmark-assets` branch and embedded inline in a sticky PR
+# comment. Heavy/label-gated: it runs only when a PR carries the `run benchmarks` label (add it to
+# trigger a run) or on manual dispatch.
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, opened]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base git ref to compare against"
+        required: false
+        default: "main"
+      maxcells:
+        description: "Cap on destination cells per tier (bounds runtime)"
+        required: false
+        default: "50000"
+
+concurrency:
+  group: benchmarks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Regridder construction benchmarks
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run benchmarks')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # push graphs to the orphan benchmark-assets branch
+      pull-requests: write  # post/update the sticky results comment
+    env:
+      JULIA_NUM_THREADS: "4"
+      BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.event.pull_request.base.sha }}
+      BASE_LABEL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.event.pull_request.base.ref }}
+      MAXCELLS: ${{ github.event_name == 'workflow_dispatch' && inputs.maxcells || '50000' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # base ref must be present for the two-ref comparison
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.11'
+      - uses: julia-actions/cache@v3
+
+      # --- Parts 1 & 4: conda-free PR-vs-base construction scaling (the common path) ----------
+      - name: Plotting environment (CairoMakie, no conda)
+        run: |
+          julia --startup-file=no -e '
+            using Pkg
+            Pkg.activate(joinpath(ENV["RUNNER_TEMP"], "plotenv"))
+            Pkg.add("CairoMakie"); Pkg.instantiate()'
+
+      - name: PR-vs-base construction scaling
+        run: |
+          julia --startup-file=no --project="$RUNNER_TEMP/plotenv" \
+            bench/compare.jl "$BASE_REF" bench/results "$MAXCELLS" "$BASE_LABEL"
+
+      # --- Part 2: ConservativeRegridding vs XESMF on the PR ref (pays conda; isolated so a
+      #     failure here does not sink the PR-vs-base graphs) -----------------------------------
+      - name: Install Python (for XESMF / esmpy)
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: ConservativeRegridding vs XESMF (PR ref)
+        continue-on-error: true
+        run: |
+          XENV="$RUNNER_TEMP/xesmfenv"
+          julia --startup-file=no -e '
+            using Pkg
+            Pkg.activate(joinpath(ENV["RUNNER_TEMP"], "xesmfenv"))
+            Pkg.develop(path = ".")
+            Pkg.add(["XESMF", "Oceananigans", "Chairmarks", "GeometryOps", "CairoMakie"])
+            Pkg.instantiate()'
+          cp bench/CondaPkg.toml "$XENV/CondaPkg.toml"
+          julia --startup-file=no --project="$XENV" --threads=4 bench/xesmf.jl bench/results/xesmf.jls "$MAXCELLS"
+          julia --startup-file=no --project="$XENV" -e '
+            include("bench/plots.jl"); using Serialization
+            plot_xesmf(deserialize("bench/results/xesmf.jls"); path = "bench/results/xesmf.png")'
+
+      - name: Upload graphs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-graphs
+          path: bench/results/*.png
+          if-no-files-found: warn
+
+      - name: Publish graphs and post sticky PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: bash bench/publish.sh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,9 +3,10 @@ name: Benchmarks
 # Regridder-construction benchmarks, modeled on Makie's PR-vs-base benchmark CI: the benchmark
 # DRIVER always comes from the PR checkout, and only the ConservativeRegridding package is swapped
 # between the PR ref and the base ref (each run in an isolated subprocess). Results are rendered to
-# graphs that are pushed to an orphan `benchmark-assets` branch and embedded inline in a sticky PR
-# comment. Heavy/label-gated: it runs only when a PR carries the `run benchmarks` label (add it to
-# trigger a run) or on manual dispatch.
+# graphs that are pushed to a separate assets repo (JuliaGeo/JuliaGeoBenchmarkResults, branch
+# `ConservativeRegridding`, via an SSH deploy key) and embedded inline in a sticky PR comment —
+# keeping image blobs out of the CR repo. Heavy/label-gated: it runs only when a PR carries the
+# `run benchmarks` label (add it to trigger a run) or on manual dispatch.
 
 on:
   pull_request:
@@ -33,7 +34,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'run benchmarks')
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # push graphs to the orphan benchmark-assets branch
+      contents: read        # checkout + local base worktree (graphs go to a separate repo via deploy key)
       pull-requests: write  # post/update the sticky results comment
     env:
       JULIA_NUM_THREADS: "4"
@@ -97,7 +98,8 @@ jobs:
       - name: Publish graphs and post sticky PR comment
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}                                # CR repo: sticky comment
+          SSH_DEPLOY_KEY: ${{ secrets.BENCHMARK_ASSETS_DEPLOY_KEY }}    # assets repo: graph push
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_ID: ${{ github.run_id }}
         run: bash bench/publish.sh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,7 +78,7 @@ jobs:
             using Pkg
             Pkg.activate(joinpath(ENV["RUNNER_TEMP"], "xesmfenv"))
             Pkg.develop(path = ".")
-            Pkg.add(["XESMF", "Oceananigans", "Chairmarks", "GeometryOps", "CairoMakie"])
+            Pkg.add(["XESMF", "Oceananigans", "Healpix", "Chairmarks", "GeometryOps", "CairoMakie"])
             Pkg.instantiate()'
           cp bench/CondaPkg.toml "$XENV/CondaPkg.toml"
           julia --startup-file=no --project="$XENV" --threads=4 bench/xesmf.jl bench/results/xesmf.jls "$MAXCELLS"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ settings.json
 
 # git worktrees
 .worktrees/
+
+# benchmark outputs (graphs + serialized results)
+bench/results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,48 @@
+# Benchmarks
+
+Regridder-**construction**-time benchmarks for ConservativeRegridding.jl. Everything here uses
+the `bench/` environment (`Project.toml` + `CondaPkg.toml`), a member of the repo workspace.
+
+## What's measured
+
+| File | What | Grids | Needs conda? |
+|---|---|---|---|
+| `scaling.jl` | construction time vs grid **size** | Oceananigans LatLon, Healpix | no |
+| `xesmf.jl` | ConservativeRegridding vs **XESMF** (ESMF) construction | Oceananigans only¹ | yes (esmpy/ESMF) |
+| `compare.jl` | **PR-vs-base** construction scaling (two-ref) | Oceananigans, Healpix | no |
+| `spectral_element.jl` | SE↔FV construction vs FV→FV baseline | ClimaCore + Oceananigans | no |
+
+¹ XESMF only regrids Oceananigans grids (via its extension), hence the Oceananigans-only scope.
+
+`grids.jl` holds the grid-pair factories (coarse source → finer destination, source at half the
+destination resolution) shared by all of the above. Tiers sweep size: Oceananigans `Ny ∈
+{16,32,64,128,256}` (cells = 2·Ny²) and Healpix `nside ∈ {8,16,32,64,128}` (cells = 12·nside²).
+
+## Run locally
+
+```bash
+# Full suite (scaling + CR-vs-XESMF) → graphs + tables in bench/results/
+julia --project=bench bench/run.jl            # all tiers
+julia --project=bench bench/run.jl 50000      # cap destination cells per tier
+
+# PR-vs-base comparison against the current checkout (writes bench/results/pr_vs_master.png)
+JULIA_NUM_THREADS=4 julia --project=bench bench/compare.jl main bench/results 50000
+```
+
+Outputs (git-ignored) land in `bench/results/`: `scaling.png`, `xesmf.png`, `pr_vs_master.png`,
+plus `*.jls` (serialized primitive rows) and `summary.md`.
+
+## CI (`.github/workflows/benchmark.yml`)
+
+Modeled on Makie's PR-vs-base benchmark job. **Label-gated**: add the **`run benchmarks`** label
+to a PR (or use *Run workflow* / `workflow_dispatch`) to trigger it. The job
+
+1. runs `compare.jl` to benchmark the **PR** and the **base** ref — the driver always comes from
+   the PR checkout; only the ConservativeRegridding package is swapped (base via a detached git
+   worktree, each ref benchmarked in an isolated subprocess so the loaded package is provable);
+2. runs the CR-vs-XESMF comparison on the PR ref (conda; isolated with `continue-on-error`);
+3. pushes the graphs to an orphan **`benchmark-assets`** branch (under `pr-<N>/`) and embeds them
+   inline in a single sticky PR comment, using only the stock `GITHUB_TOKEN` (no bot PAT / gist).
+
+The full-resolution graphs are also uploaded as a workflow **artifact**. Fork PRs get a read-only
+token, so the push/comment is skipped there (the artifact still uploads).

--- a/bench/README.md
+++ b/bench/README.md
@@ -41,8 +41,12 @@ to a PR (or use *Run workflow* / `workflow_dispatch`) to trigger it. The job
    the PR checkout; only the ConservativeRegridding package is swapped (base via a detached git
    worktree, each ref benchmarked in an isolated subprocess so the loaded package is provable);
 2. runs the CR-vs-XESMF comparison on the PR ref (conda; isolated with `continue-on-error`);
-3. pushes the graphs to an orphan **`benchmark-assets`** branch (under `pr-<N>/`) and embeds them
-   inline in a single sticky PR comment, using only the stock `GITHUB_TOKEN` (no bot PAT / gist).
+3. pushes the graphs to a **separate** assets repo — `JuliaGeo/JuliaGeoBenchmarkResults`, branch
+   **`ConservativeRegridding`**, under `pr-<N>/` — and embeds them inline in a single sticky PR
+   comment. Keeping the PNG blobs out of this repo avoids bloating its git history.
 
-The full-resolution graphs are also uploaded as a workflow **artifact**. Fork PRs get a read-only
-token, so the push/comment is skipped there (the artifact still uploads).
+The cross-repo push uses an **SSH deploy key** (write-scoped to the assets repo only) stored as the
+`BENCHMARK_ASSETS_DEPLOY_KEY` secret — the stock `GITHUB_TOKEN` can't push to another repo. The
+sticky comment is still posted to this repo with the stock token. The full-resolution graphs are
+also uploaded as a workflow **artifact**. Fork PRs get neither the secret nor a writable token, so
+the push/comment is skipped there (the artifact still uploads).

--- a/bench/README.md
+++ b/bench/README.md
@@ -50,3 +50,14 @@ The cross-repo push uses an **SSH deploy key** (write-scoped to the assets repo 
 sticky comment is still posted to this repo with the stock token. The full-resolution graphs are
 also uploaded as a workflow **artifact**. Fork PRs get neither the secret nor a writable token, so
 the push/comment is skipped there (the artifact still uploads).
+
+## Profiling
+
+`profile_cr.jl` breaks `Regridder` construction into its phases (candidate search, COO assembly,
+sparse build, per-cell areas), times each threaded and serial, and profiles the hot path.
+`construction-performance.md` writes up where the time goes and the trig-free broad-phase
+optimization it motivated (#112).
+
+```bash
+julia --project=bench --threads=4 bench/profile_cr.jl
+```

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -1,0 +1,82 @@
+# Two-ref PR-vs-base regridder-construction comparison — the core of the benchmark CI.
+#
+#     julia --project=<env-with-CairoMakie> bench/compare.jl <base_ref> <outdir> [maxcells] [base_label]
+#
+# Strategy (Makie-style: the driver comes from the PR, only the package is swapped per ref):
+#   * For each ref, build a fresh CONDA-FREE temp environment that `Pkg.develop`s the
+#     ConservativeRegridding source for that ref, then run THIS repo's bench/scaling.jl in an
+#     isolated subprocess against it. The driver file is always the PR's; only the loaded
+#     ConservativeRegridding differs. scaling.jl prints `pathof(ConservativeRegridding)` so each
+#     ref's package is provable in the logs.
+#   * The base ref's source comes from a detached git worktree under .worktrees/base. (The base
+#     ref need not contain bench/ — the driver is invoked from the PR checkout.)
+#   * This parent process only loads CairoMakie + Serialization (via plots.jl) — never CR — so
+#     there is no PR-vs-base package-version clash in the plotting step.
+#   * Thread count is pinned identically for both refs (JULIA_NUM_THREADS) for a fair compare.
+
+using Serialization
+include(joinpath(@__DIR__, "plots.jl"))
+
+const REPO     = normpath(joinpath(@__DIR__, ".."))
+const NTHREADS = get(ENV, "JULIA_NUM_THREADS", "4")
+
+base_ref   = length(ARGS) >= 1 ? ARGS[1] : "main"            # git ref/SHA to check out for base
+outdir     = length(ARGS) >= 2 ? ARGS[2] : joinpath(@__DIR__, "results")
+maxcells   = length(ARGS) >= 3 ? parse(Int, ARGS[3]) : 50_000
+base_label = length(ARGS) >= 4 ? ARGS[4] : base_ref           # human label for plots/tables (e.g. "main")
+mkpath(outdir)
+
+# A conda-free environment that dev-depends on the ConservativeRegridding at `crpath`, plus the
+# packages scaling.jl needs (Oceananigans + Healpix activate CR's extensions).
+function build_scaling_env(crpath)
+    env = mktempdir()
+    code = """
+    using Pkg
+    Pkg.develop(path = raw"$(crpath)")
+    Pkg.add(["Oceananigans", "Healpix", "Chairmarks", "GeometryOps"])
+    Pkg.instantiate()
+    """
+    run(`julia --startup-file=no --project=$(env) -e $(code)`)
+    return env
+end
+
+function run_ref(label, crpath, outjls)
+    @info "benchmarking ref" label crpath
+    env = build_scaling_env(crpath)
+    driver = joinpath(REPO, "bench", "scaling.jl")
+    run(`julia --startup-file=no --project=$(env) --threads=$(NTHREADS) $(driver) $(outjls) $(maxcells)`)
+    return deserialize(outjls)
+end
+
+# PR ref = this checkout.
+pr_rows = run_ref("PR", REPO, joinpath(outdir, "pr.jls"))
+
+# Base ref via a detached worktree (.worktrees/ is gitignored). Try the ref as given, then
+# fall back to origin/<ref> (CI fetches base as a remote-tracking ref, not a local branch).
+function add_base_worktree(base_wt, ref)
+    ispath(base_wt) && run(`git -C $(REPO) worktree remove --force $(base_wt)`)
+    try
+        run(`git -C $(REPO) worktree add --force --detach $(base_wt) $(ref)`)
+    catch
+        run(`git -C $(REPO) worktree add --force --detach $(base_wt) origin/$(ref)`)
+    end
+end
+
+base_wt = joinpath(REPO, ".worktrees", "base")
+base_rows = try
+    add_base_worktree(base_wt, base_ref)
+    run_ref("base ($base_label)", base_wt, joinpath(outdir, "base.jls"))
+catch e
+    @error "base benchmark failed; degrading to PR-only comparison" exception = (e, catch_backtrace())
+    NamedTuple[]
+finally
+    try
+        ispath(base_wt) && run(`git -C $(REPO) worktree remove --force $(base_wt)`)
+    catch
+    end
+end
+
+plot_pr_vs_master(pr_rows, base_rows; path = joinpath(outdir, "pr_vs_master.png"), base_label = base_label)
+open(io -> println(io, summary_markdown(pr_rows, base_rows; base_label = base_label)),
+    joinpath(outdir, "summary.md"), "w")
+@info "comparison written" outdir

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -76,6 +76,8 @@ finally
     end
 end
 
+# The PR's own rows ARE the Part-1 scaling data (one curve per grid family).
+plot_scaling(pr_rows; path = joinpath(outdir, "scaling.png"))
 plot_pr_vs_master(pr_rows, base_rows; path = joinpath(outdir, "pr_vs_master.png"), base_label = base_label)
 open(io -> println(io, summary_markdown(pr_rows, base_rows; base_label = base_label)),
     joinpath(outdir, "summary.md"), "w")

--- a/bench/construction-performance.md
+++ b/bench/construction-performance.md
@@ -1,0 +1,99 @@
+# Regridder construction performance
+
+An investigation into where `Regridder` construction spends its time on spherical grids, and
+why ESMF (via XESMF) outruns ConservativeRegridding at conservative weight generation. Prompted
+by the CR-vs-XESMF benchmark (`bench/xesmf.jl`), which shows XESMF ~3× faster than threaded CR
+and ~7× faster than serial CR across all tiers on the CI runner.
+
+## Method
+
+Each phase of `Regridder(Spherical(), dst, src)` was timed separately (min of several reps) for
+the Oceananigans LatLon tiers, threaded (4 Julia threads) and serial, plus a statistical
+`Profile` of the dominant phase. Numbers below are on an Apple-Silicon laptop, so absolute ms are
+~10× faster than the shared ubuntu CI runner — but the **phase proportions and speedup ratios are
+platform-independent**. Reproduce with `bench/profile_cr.jl` (a thin wrapper over the internal
+phase functions).
+
+The construction phases are: **treeify** → **candidate search** (dual depth-first search over the
+two quadtrees, extent-pruned) → **COO assembly** (per candidate pair: Sutherland–Hodgman clip +
+spherical area) → **sparse build** → **per-cell areas**.
+
+## Where the time went (before)
+
+Oceananigans `Ny=128` → 32,768 dst cells, 8,192 src cells; 274,688 candidate pairs, 48,640 nnz:
+
+| phase | threaded | serial | parallel scaling |
+| --- | ---: | ---: | ---: |
+| candidate search | 74.2 ms (52%) | 277.6 ms (55%) | 3.7× |
+| COO assembly | 57.8 ms (40%) | 209.8 ms (42%) | 3.6× |
+| per-cell areas | 10.6 ms (7%) | 11.7 ms (2%) | ~1× (serial) |
+| treeify + sparse | 1.1 ms (<1%) | 0.9 ms (<1%) | — |
+| **total** | **143.8 ms** | **500.0 ms** | |
+
+## Three root causes of the gap
+
+1. **Loose broad phase → 5.6× wasted clips.** The dual DFS emits **274,688** candidate pairs but
+   only **48,640** produce nonzero area — ~82% of the (expensive) Sutherland–Hodgman clips return
+   empty. Spherical caps over-approximate lat/lon cells (a circle bounding a rectangle, worse near
+   the poles), so the broad phase passes far more pairs than truly overlap.
+
+2. **~573 MB of allocation in assembly (~2 KB per clip).** Every clip allocates fresh polygon
+   buffers (`grow_to!`, `array_new_memory`, `GenericMemory`). ESMF is allocation-free Fortran.
+   This allocator lives in GeometryOps (`_intersection_sutherland_hodgman`), upstream of CR.
+
+3. **Trig-heavy exact spherical math — some of it needless.** The profile was dominated by
+   `_spherical_cap` (CR's broad-phase extent), which did **4 `slerp`s + 8 `spherical_distance`s
+   per node**, all `atan`/`cos`/`sqrt`. The great-circle midpoint at `t=0.5` is *exactly*
+   `normalize(a+b)` (no slerp), and the max angular distance is `acos` of the **min cosine** (dot
+   products + one `acos`) — removable trig with no accuracy loss.
+
+### Secondary findings
+
+- The `# this is just serial … big bottleneck` TODO at `intersection_areas.jl:88` is **stale** —
+  candidate search parallelizes 3.7×.
+- `areas` (per-cell) runs serially (~7% of threaded total) — free parallelism left on the table.
+- `getchild` allocates per subdivision (the lazy quadtree rebuilds nodes each traversal).
+
+## Fix applied: trig-free broad-phase extents
+
+Landed in **#112** (against `as/parallelize-sparsematrix`). Rewrote `_spherical_cap` and the
+`ExplicitPolygonGrid{<:Spherical}` extent (`src/trees/grids.jl`):
+
+- **Great-circle edge midpoint** `slerp(a, b, 0.5)` → `normalize(a + b)` — provably identical for
+  non-antipodal `a, b` (verified to ~15 digits).
+- **Cap radius** `max(spherical_distance(center, ·))` → `acos(clamp(min(dot(center, ·)), -1, 1))`
+  — one `acos` instead of per-point trig.
+- **Antipodal guard** (`_midcos`): on a large index-rectangle, an edge can span ~180° so its two
+  corners are antipodal and `normalize(a+b)` is `NaN`; there the endpoints already force the cap
+  wide, so the midpoint is dropped from the radius. (GeometryOps' `slerp` returned a finite
+  arbitrary point here; the explicit guard is more principled and avoids the `NaN`.)
+
+### Result
+
+Same `Ny=128` workload, after the change:
+
+| phase | threaded | serial |
+| --- | ---: | ---: |
+| candidate search | **18.5 ms** (21%) | **64.1 ms** (23%) |
+| COO assembly | 59.6 ms (66%) | 203.3 ms (73%) |
+| per-cell areas | 10.9 ms (12%) | 11.2 ms (4%) |
+| **total** | **89.9 ms** | **279.6 ms** |
+
+- **Candidate search: 4.0× faster (threaded), 4.3× (serial).**
+- **Total construction: 1.6× faster (threaded), 1.79× (serial).**
+- **Correctness preserved:** candidate count (274,688) and nnz (48,640) are byte-identical before
+  and after; the `cell_range_extent spherical: bounding cap` characterization test, the dual-DFS
+  tests, and the regridding-conservation use-case tests all pass unchanged.
+
+Candidate search drops from ~55% to ~21% of construction — **COO assembly is now the bottleneck**
+(66–73%).
+
+## Remaining gap / next levers
+
+Now that assembly dominates, the next targets (in rough leverage order):
+
+1. **Allocation-free clipping (upstream).** Reusing buffers in GeometryOps' Sutherland–Hodgman
+   would attack the 573 MB / ~2 KB-per-clip head-on — the single biggest assembly cost.
+2. **Tighten the broad phase** to cut the 5.6× false-positive clips (a cheap secondary reject, or
+   a bound tighter than the spherical cap before the full clip).
+3. **Parallelize `areas`**, and fix the stale candidate-search TODO comment.

--- a/bench/grids.jl
+++ b/bench/grids.jl
@@ -1,0 +1,53 @@
+# Grid-pair factories for the benchmark suite, parametrized by a resolution tier.
+#
+# Single source of truth shared by scaling.jl, xesmf.jl, run.jl and compare.jl. Each factory
+# returns a NamedTuple describing one (dst, src) regridding workload within ONE grid family:
+# a coarse source regridded onto a finer destination (src at half the destination resolution).
+# Sweeping the tier isolates SIZE / scaling, which is the focus here — unlike the sweat tests,
+# which instead enumerate grid *natures* (tripolar, rotated, gilbert, …).
+#
+# Idempotent: safe to `include` more than once (run.jl pulls in both scaling.jl and xesmf.jl,
+# each of which includes this file).
+
+if !@isdefined(_BENCH_GRIDS_LOADED)
+const _BENCH_GRIDS_LOADED = true
+
+import GeometryOps as GO
+using Oceananigans: LatitudeLongitudeGrid
+import Healpix
+
+const SPHERE_RADIUS = GO.Spherical().radius
+
+# Resolution tiers. Oceananigans is indexed by Ny (Nx = 2Ny); Healpix by nside (a power of 2).
+# ncells_dst = 2Ny²  ∈ {512, 2k, 8k, 32k, 131k};  12 nside² ∈ {768, 3k, 12k, 49k, 196k}.
+const OCEANANIGANS_NY = [16, 32, 64, 128, 256]
+const HEALPIX_NSIDE   = [8, 16, 32, 64, 128]
+
+latlongrid(Nx, Ny) = LatitudeLongitudeGrid(; size = (Nx, Ny, 1),
+    longitude = (0, 360), latitude = (-90, 90), z = (0, 1), radius = SPHERE_RADIUS)
+
+healpixmap(nside) = Healpix.HealpixMap{Float64, Healpix.RingOrder}(nside)
+
+# Oceananigans LatLon workload at tier Ny: dst = (2Ny, Ny), src = (Ny, Ny÷2).
+function oceananigans_pair(Ny::Integer)
+    dst = latlongrid(2Ny, Ny)
+    src = latlongrid(Ny, Ny ÷ 2)
+    return (; family = "Oceananigans", tier = Int(Ny),
+        ncells_dst = 2Ny^2, ncells_src = Ny * (Ny ÷ 2), dst, src)
+end
+
+# Healpix workload at tier nside: dst = nside, src = nside÷2 (still a power of two).
+function healpix_pair(nside::Integer)
+    dst = healpixmap(nside)
+    src = healpixmap(nside ÷ 2)
+    return (; family = "Healpix", tier = Int(nside),
+        ncells_dst = 12 * nside^2, ncells_src = 12 * (nside ÷ 2)^2, dst, src)
+end
+
+# Tier lists honoring a max-destination-cells cap (used to bound CI runtime).
+oceananigans_tiers(; maxcells = typemax(Int)) =
+    [oceananigans_pair(Ny) for Ny in OCEANANIGANS_NY if 2Ny^2 <= maxcells]
+healpix_tiers(; maxcells = typemax(Int)) =
+    [healpix_pair(nside) for nside in HEALPIX_NSIDE if 12 * nside^2 <= maxcells]
+
+end # _BENCH_GRIDS_LOADED

--- a/bench/plots.jl
+++ b/bench/plots.jl
@@ -1,0 +1,137 @@
+# CairoMakie rendering of benchmark results. Kept separate from the benchmark drivers so the
+# drivers (scaling.jl, xesmf.jl) stay free of plotting/conda dependencies. Operates purely on
+# the primitive NamedTuple rows produced by the drivers — never loads ConservativeRegridding —
+# so it can plot PR and base results side by side without a package-version clash.
+
+using CairoMakie
+using Serialization
+using Printf
+
+const _FAMILY_COLOR = Dict("Oceananigans" => :steelblue, "Healpix" => :darkorange)
+const _METHOD_COLOR = Dict("CR" => :steelblue, "CR-serial" => :seagreen, "XESMF" => :firebrick)
+
+_methodlabel(m) = m == "CR" ? "ConservativeRegridding (threaded)" :
+                  m == "CR-serial" ? "ConservativeRegridding (serial)" : "XESMF / ESMF"
+
+_fmt_time(t) = t >= 1 ? @sprintf("%.2f s", t) :
+               t >= 1e-3 ? @sprintf("%.1f ms", t * 1e3) : @sprintf("%.0f µs", t * 1e6)
+_humancells(n) = n >= 1000 ? @sprintf("%.0fk", n / 1000) : string(n)
+
+# --- Part 1: construction scaling, one line per grid family ---------------------------------
+function plot_scaling(rows; path)
+    rows = filter(r -> r.method == "CR", rows)
+    fig = Figure(size = (820, 540))
+    ax = Axis(fig[1, 1]; xscale = log10, yscale = log10,
+        xlabel = "destination cells (source at half-resolution)",
+        ylabel = "construction time (s)",
+        title = "Regridder construction scaling by grid family")
+    for fam in sort(unique(r.family for r in rows))
+        sub = sort(filter(r -> r.family == fam, rows); by = r -> r.ncells_dst)
+        isempty(sub) && continue
+        scatterlines!(ax, [Float64(r.ncells_dst) for r in sub], [r.time_s for r in sub];
+            label = fam, color = get(_FAMILY_COLOR, fam, :black), markersize = 11, linewidth = 2)
+    end
+    !isempty(rows) && axislegend(ax; position = :lt)
+    nthreads = isempty(rows) ? 0 : rows[1].nthreads
+    Label(fig[2, 1], "Julia threads: $nthreads · lower is better";
+        fontsize = 11, color = :gray40, tellwidth = false)
+    save(path, fig)
+    return path
+end
+
+# --- Part 2: CR (threaded & serial) vs XESMF construction time ------------------------------
+function plot_xesmf(rows; path)
+    fig = Figure(size = (840, 540))
+    ax = Axis(fig[1, 1]; xscale = log10, yscale = log10,
+        xlabel = "destination cells (source at half-resolution)",
+        ylabel = "construction time (s)",
+        title = "Construction time: ConservativeRegridding vs XESMF (Oceananigans)")
+    for m in ["CR", "CR-serial", "XESMF"]
+        sub = sort(filter(r -> r.method == m, rows); by = r -> r.ncells_dst)
+        isempty(sub) && continue
+        scatterlines!(ax, [Float64(r.ncells_dst) for r in sub], [r.time_s for r in sub];
+            label = _methodlabel(m), color = _METHOD_COLOR[m], markersize = 11, linewidth = 2)
+    end
+    axislegend(ax; position = :lt)
+    nthreads = isempty(rows) ? 0 : rows[1].nthreads
+    Label(fig[2, 1], "CR threaded uses $nthreads Julia threads; XESMF weight-gen is ESMF-controlled · lower is better";
+        fontsize = 11, color = :gray40, tellwidth = false)
+    save(path, fig)
+    return path
+end
+
+# --- Part 4 (CI): PR-vs-base construction-time ratio, one line per family -------------------
+function plot_pr_vs_master(pr_rows, base_rows; path, base_label = "base")
+    pr = filter(r -> r.method == "CR", pr_rows)
+    basemap = Dict((r.family, r.tier) => r.time_s for r in base_rows if r.method == "CR")
+    fig = Figure(size = (860, 540))
+    ax = Axis(fig[1, 1]; xscale = log10,
+        xlabel = "destination cells (source at half-resolution)",
+        ylabel = "construction time ratio  (PR / $base_label)",
+        title = "Construction time change: PR vs $base_label")
+    hspan!(ax, 1.0, 1e3; color = (:tomato, 0.10))      # slower than base
+    hspan!(ax, 1e-3, 1.0; color = (:seagreen, 0.10))   # faster than base
+    hlines!(ax, [1.0]; color = :gray50, linestyle = :dash)
+    ratios = Float64[]
+    plotted = false
+    for fam in sort(unique(r.family for r in pr))
+        sub = sort(filter(r -> r.family == fam, pr); by = r -> r.ncells_dst)
+        xs = Float64[]; ys = Float64[]
+        for r in sub
+            bt = get(basemap, (r.family, r.tier), NaN)
+            isfinite(bt) && bt > 0 || continue
+            push!(xs, r.ncells_dst); push!(ys, r.time_s / bt); push!(ratios, r.time_s / bt)
+        end
+        isempty(xs) && continue
+        scatterlines!(ax, xs, ys; label = fam, color = get(_FAMILY_COLOR, fam, :black),
+            markersize = 11, linewidth = 2)
+        plotted = true
+    end
+    if plotted
+        axislegend(ax; position = :rt)
+        hi = max(1.15, maximum(ratios) * 1.1)
+        lo = min(0.85, minimum(ratios) * 0.9)
+        ylims!(ax, lo, hi)
+        Label(fig[2, 1], "below 1.0 (green) = PR faster · above 1.0 (red) = PR slower · shared CI runners are noisy";
+            fontsize = 11, color = :gray40, tellwidth = false)
+    else
+        text!(ax, 0.5, 0.5; text = "no base data\n(base build failed or unavailable)",
+            space = :relative, align = (:center, :center), color = :gray50)
+        ylims!(ax, 0.0, 2.0)
+    end
+    save(path, fig)
+    return path
+end
+
+# --- Markdown summaries (for the PR comment) ------------------------------------------------
+function summary_markdown(pr_rows, base_rows = NamedTuple[]; base_label = "base")
+    pr = filter(r -> r.method == "CR", pr_rows)
+    base = Dict((r.family, r.tier) => r for r in base_rows if r.method == "CR")
+    io = IOBuffer()
+    println(io, "| family | dst cells | PR | $base_label | ratio | PR allocs | nnz |")
+    println(io, "|---|--:|--:|--:|--:|--:|--:|")
+    for r in sort(pr; by = r -> (r.family, r.ncells_dst))
+        b = get(base, (r.family, r.tier), nothing)
+        bt = isnothing(b) ? "—" : _fmt_time(b.time_s)
+        ratio = isnothing(b) ? "—" : @sprintf("%.2f×", r.time_s / b.time_s)
+        println(io, "| $(r.family) | $(r.ncells_dst) | $(_fmt_time(r.time_s)) | $bt | $ratio | $(r.allocs) | $(r.nnz) |")
+    end
+    return String(take!(io))
+end
+
+function xesmf_summary_markdown(rows)
+    tiers = sort(unique((r.tier, r.ncells_dst) for r in rows); by = t -> t[2])
+    bym = Dict((r.method, r.tier) => r for r in rows)
+    io = IOBuffer()
+    println(io, "| dst cells | CR (threaded) | CR (serial) | XESMF | CR/XESMF |")
+    println(io, "|--:|--:|--:|--:|--:|")
+    for (tier, ncells) in tiers
+        cr = get(bym, ("CR", tier), nothing)
+        crs = get(bym, ("CR-serial", tier), nothing)
+        xe = get(bym, ("XESMF", tier), nothing)
+        f(x) = isnothing(x) ? "—" : _fmt_time(x.time_s)
+        speed = (isnothing(cr) || isnothing(xe)) ? "—" : @sprintf("%.2f×", cr.time_s / xe.time_s)
+        println(io, "| $ncells | $(f(cr)) | $(f(crs)) | $(f(xe)) | $speed |")
+    end
+    return String(take!(io))
+end

--- a/bench/plots.jl
+++ b/bench/plots.jl
@@ -7,11 +7,13 @@ using CairoMakie
 using Serialization
 using Printf
 
-const _FAMILY_COLOR = Dict("Oceananigans" => :steelblue, "Healpix" => :darkorange)
-const _METHOD_COLOR = Dict("CR" => :steelblue, "CR-serial" => :seagreen, "XESMF" => :firebrick)
+# Categorical series use Makie's default palette (Wong colors), assigned positionally so each
+# line and its inter-quartile error bars share a colour.
+const _PALETTE = Makie.wong_colors()
+_seriescolor(i) = _PALETTE[mod1(i, length(_PALETTE))]
 
 _methodlabel(m) = m == "CR" ? "ConservativeRegridding (threaded)" :
-                  m == "CR-serial" ? "ConservativeRegridding (serial)" : "XESMF / ESMF"
+                  m == "CR-serial" ? "ConservativeRegridding (serial)" : "XESMF"
 
 _fmt_time(t) = t >= 1 ? @sprintf("%.2f s", t) :
                t >= 1e-3 ? @sprintf("%.1f ms", t * 1e3) : @sprintf("%.0f µs", t * 1e6)
@@ -30,10 +32,10 @@ function plot_scaling(rows; path)
         xlabel = "destination cells (source at half-resolution)",
         ylabel = "construction time (s)",
         title = "Regridder construction scaling by grid family")
-    for fam in sort(unique(r.family for r in rows))
+    for (i, fam) in enumerate(sort(unique(r.family for r in rows)))
         sub = sort(filter(r -> r.family == fam, rows); by = r -> r.ncells_dst)
         isempty(sub) && continue
-        col = get(_FAMILY_COLOR, fam, :black)
+        col = _seriescolor(i)
         xs = [Float64(r.ncells_dst) for r in sub]
         rangebars!(ax, xs, [_lo(r) for r in sub], [_hi(r) for r in sub];
             color = col, whiskerwidth = 7, linewidth = 1.5)
@@ -55,10 +57,10 @@ function plot_xesmf(rows; path)
         xlabel = "destination cells (source at half-resolution)",
         ylabel = "construction time (s)",
         title = "Construction time: ConservativeRegridding vs XESMF (Oceananigans)")
-    for m in ["CR", "CR-serial", "XESMF"]
+    for (i, m) in enumerate(["CR", "CR-serial", "XESMF"])
         sub = sort(filter(r -> r.method == m, rows); by = r -> r.ncells_dst)
         isempty(sub) && continue
-        col = _METHOD_COLOR[m]
+        col = _seriescolor(i)
         xs = [Float64(r.ncells_dst) for r in sub]
         rangebars!(ax, xs, [_lo(r) for r in sub], [_hi(r) for r in sub];
             color = col, whiskerwidth = 7, linewidth = 1.5)
@@ -87,9 +89,9 @@ function plot_pr_vs_master(pr_rows, base_rows; path, base_label = "base")
     hlines!(ax, [1.0]; color = :gray50, linestyle = :dash)
     yvals = Float64[]
     plotted = false
-    for fam in sort(unique(r.family for r in pr))
+    for (i, fam) in enumerate(sort(unique(r.family for r in pr)))
         sub = sort(filter(r -> r.family == fam, pr); by = r -> r.ncells_dst)
-        col = get(_FAMILY_COLOR, fam, :black)
+        col = _seriescolor(i)
         xs = Float64[]; ys = Float64[]; rlos = Float64[]; rhis = Float64[]
         for r in sub
             b = get(basemap, (r.family, r.tier), nothing)

--- a/bench/plots.jl
+++ b/bench/plots.jl
@@ -17,6 +17,11 @@ _fmt_time(t) = t >= 1 ? @sprintf("%.2f s", t) :
                t >= 1e-3 ? @sprintf("%.1f ms", t * 1e3) : @sprintf("%.0f µs", t * 1e6)
 _humancells(n) = n >= 1000 ? @sprintf("%.0fk", n / 1000) : string(n)
 
+# Per-point error-bar bounds (inter-quartile range), tolerant of older rows without a spread.
+_lo(r) = hasproperty(r, :time_lo) ? r.time_lo : r.time_s
+_hi(r) = hasproperty(r, :time_hi) ? r.time_hi : r.time_s
+_nsamp(r) = hasproperty(r, :nsamples) ? r.nsamples : 1
+
 # --- Part 1: construction scaling, one line per grid family ---------------------------------
 function plot_scaling(rows; path)
     rows = filter(r -> r.method == "CR", rows)
@@ -28,8 +33,12 @@ function plot_scaling(rows; path)
     for fam in sort(unique(r.family for r in rows))
         sub = sort(filter(r -> r.family == fam, rows); by = r -> r.ncells_dst)
         isempty(sub) && continue
-        scatterlines!(ax, [Float64(r.ncells_dst) for r in sub], [r.time_s for r in sub];
-            label = fam, color = get(_FAMILY_COLOR, fam, :black), markersize = 11, linewidth = 2)
+        col = get(_FAMILY_COLOR, fam, :black)
+        xs = [Float64(r.ncells_dst) for r in sub]
+        rangebars!(ax, xs, [_lo(r) for r in sub], [_hi(r) for r in sub];
+            color = col, whiskerwidth = 7, linewidth = 1.5)
+        scatterlines!(ax, xs, [r.time_s for r in sub];
+            label = fam, color = col, markersize = 11, linewidth = 2)
     end
     !isempty(rows) && axislegend(ax; position = :lt)
     nthreads = isempty(rows) ? 0 : rows[1].nthreads
@@ -49,8 +58,12 @@ function plot_xesmf(rows; path)
     for m in ["CR", "CR-serial", "XESMF"]
         sub = sort(filter(r -> r.method == m, rows); by = r -> r.ncells_dst)
         isempty(sub) && continue
-        scatterlines!(ax, [Float64(r.ncells_dst) for r in sub], [r.time_s for r in sub];
-            label = _methodlabel(m), color = _METHOD_COLOR[m], markersize = 11, linewidth = 2)
+        col = _METHOD_COLOR[m]
+        xs = [Float64(r.ncells_dst) for r in sub]
+        rangebars!(ax, xs, [_lo(r) for r in sub], [_hi(r) for r in sub];
+            color = col, whiskerwidth = 7, linewidth = 1.5)
+        scatterlines!(ax, xs, [r.time_s for r in sub];
+            label = _methodlabel(m), color = col, markersize = 11, linewidth = 2)
     end
     axislegend(ax; position = :lt)
     nthreads = isempty(rows) ? 0 : rows[1].nthreads
@@ -63,7 +76,7 @@ end
 # --- Part 4 (CI): PR-vs-base construction-time ratio, one line per family -------------------
 function plot_pr_vs_master(pr_rows, base_rows; path, base_label = "base")
     pr = filter(r -> r.method == "CR", pr_rows)
-    basemap = Dict((r.family, r.tier) => r.time_s for r in base_rows if r.method == "CR")
+    basemap = Dict((r.family, r.tier) => r for r in base_rows if r.method == "CR")
     fig = Figure(size = (860, 540))
     ax = Axis(fig[1, 1]; xscale = log10,
         xlabel = "destination cells (source at half-resolution)",
@@ -72,27 +85,30 @@ function plot_pr_vs_master(pr_rows, base_rows; path, base_label = "base")
     hspan!(ax, 1.0, 1e3; color = (:tomato, 0.10))      # slower than base
     hspan!(ax, 1e-3, 1.0; color = (:seagreen, 0.10))   # faster than base
     hlines!(ax, [1.0]; color = :gray50, linestyle = :dash)
-    ratios = Float64[]
+    yvals = Float64[]
     plotted = false
     for fam in sort(unique(r.family for r in pr))
         sub = sort(filter(r -> r.family == fam, pr); by = r -> r.ncells_dst)
-        xs = Float64[]; ys = Float64[]
+        col = get(_FAMILY_COLOR, fam, :black)
+        xs = Float64[]; ys = Float64[]; rlos = Float64[]; rhis = Float64[]
         for r in sub
-            bt = get(basemap, (r.family, r.tier), NaN)
-            isfinite(bt) && bt > 0 || continue
-            push!(xs, r.ncells_dst); push!(ys, r.time_s / bt); push!(ratios, r.time_s / bt)
+            b = get(basemap, (r.family, r.tier), nothing)
+            (isnothing(b) || b.time_s <= 0) && continue
+            push!(xs, r.ncells_dst)
+            push!(ys, r.time_s / b.time_s)
+            push!(rlos, _lo(r) / _hi(b))   # conservative inter-quartile band on the ratio
+            push!(rhis, _hi(r) / _lo(b))
         end
         isempty(xs) && continue
-        scatterlines!(ax, xs, ys; label = fam, color = get(_FAMILY_COLOR, fam, :black),
-            markersize = 11, linewidth = 2)
+        append!(yvals, ys); append!(yvals, rlos); append!(yvals, rhis)
+        rangebars!(ax, xs, rlos, rhis; color = col, whiskerwidth = 7, linewidth = 1.5)
+        scatterlines!(ax, xs, ys; label = fam, color = col, markersize = 11, linewidth = 2)
         plotted = true
     end
     if plotted
         axislegend(ax; position = :rt)
-        hi = max(1.15, maximum(ratios) * 1.1)
-        lo = min(0.85, minimum(ratios) * 0.9)
-        ylims!(ax, lo, hi)
-        Label(fig[2, 1], "below 1.0 (green) = PR faster · above 1.0 (red) = PR slower · shared CI runners are noisy";
+        ylims!(ax, min(0.85, minimum(yvals) * 0.95), max(1.15, maximum(yvals) * 1.05))
+        Label(fig[2, 1], "below 1.0 (green) = PR faster · above 1.0 (red) = PR slower · bars = inter-quartile range · shared CI runners are noisy";
             fontsize = 11, color = :gray40, tellwidth = false)
     else
         text!(ax, 0.5, 0.5; text = "no base data\n(base build failed or unavailable)",
@@ -108,13 +124,13 @@ function summary_markdown(pr_rows, base_rows = NamedTuple[]; base_label = "base"
     pr = filter(r -> r.method == "CR", pr_rows)
     base = Dict((r.family, r.tier) => r for r in base_rows if r.method == "CR")
     io = IOBuffer()
-    println(io, "| family | dst cells | PR | $base_label | ratio | PR allocs | nnz |")
-    println(io, "|---|--:|--:|--:|--:|--:|--:|")
+    println(io, "| family | dst cells | PR (median) | $base_label | ratio | n | PR allocs | nnz |")
+    println(io, "|---|--:|--:|--:|--:|--:|--:|--:|")
     for r in sort(pr; by = r -> (r.family, r.ncells_dst))
         b = get(base, (r.family, r.tier), nothing)
         bt = isnothing(b) ? "—" : _fmt_time(b.time_s)
         ratio = isnothing(b) ? "—" : @sprintf("%.2f×", r.time_s / b.time_s)
-        println(io, "| $(r.family) | $(r.ncells_dst) | $(_fmt_time(r.time_s)) | $bt | $ratio | $(r.allocs) | $(r.nnz) |")
+        println(io, "| $(r.family) | $(r.ncells_dst) | $(_fmt_time(r.time_s)) | $bt | $ratio | $(_nsamp(r)) | $(r.allocs) | $(r.nnz) |")
     end
     return String(take!(io))
 end
@@ -123,15 +139,16 @@ function xesmf_summary_markdown(rows)
     tiers = sort(unique((r.tier, r.ncells_dst) for r in rows); by = t -> t[2])
     bym = Dict((r.method, r.tier) => r for r in rows)
     io = IOBuffer()
-    println(io, "| dst cells | CR (threaded) | CR (serial) | XESMF | CR/XESMF |")
-    println(io, "|--:|--:|--:|--:|--:|")
+    println(io, "| dst cells | CR (threaded) | CR (serial) | XESMF | CR/XESMF | n |")
+    println(io, "|--:|--:|--:|--:|--:|--:|")
     for (tier, ncells) in tiers
         cr = get(bym, ("CR", tier), nothing)
         crs = get(bym, ("CR-serial", tier), nothing)
         xe = get(bym, ("XESMF", tier), nothing)
         f(x) = isnothing(x) ? "—" : _fmt_time(x.time_s)
         speed = (isnothing(cr) || isnothing(xe)) ? "—" : @sprintf("%.2f×", cr.time_s / xe.time_s)
-        println(io, "| $ncells | $(f(cr)) | $(f(crs)) | $(f(xe)) | $speed |")
+        n = isnothing(cr) ? "—" : string(_nsamp(cr))
+        println(io, "| $ncells | $(f(cr)) | $(f(crs)) | $(f(xe)) | $speed | $n |")
     end
     return String(take!(io))
 end

--- a/bench/profile_cr.jl
+++ b/bench/profile_cr.jl
@@ -1,0 +1,86 @@
+# Phase-level profiler for Regridder construction on spherical grids — the tool behind
+# bench/construction-performance.md. Times each phase separately (treeify → candidate search →
+# COO assembly → sparse build → per-cell areas), threaded & serial, at two Oceananigans tiers,
+# then prints a statistical Profile of the dominant phase. Run in the bench env:
+#
+#     julia --project=bench --threads=4 bench/profile_cr.jl
+#
+# It reaches into the internal phase functions (get_all_candidate_pairs, _parallel_coo, …) so each
+# phase can be timed against fixed inputs; the public path is just `Regridder(manifold, dst, src)`.
+
+using ConservativeRegridding
+const CR = ConservativeRegridding
+const Trees = CR.Trees
+import GeometryOps as GO
+using SparseArrays
+using Profile
+using Printf
+
+include(joinpath(@__DIR__, "grids.jl"))
+
+bestof(f, n) = minimum(@elapsed(f()) for _ in 1:n)
+
+const M = GO.Spherical()
+
+function phase_times(Ny; threaded::Bool)
+    pair = oceananigans_pair(Ny)
+    dst, src = pair.dst, pair.src
+    tf = CR.booltype(threaded)
+    predicate_f = GO.UnitSpherical._intersects
+    op = CR.DefaultIntersectionOperator(M)
+    style = CR.IntersectionReturnStyle(op)
+    npart = Threads.nthreads() * 4
+
+    dst_tree = Trees.treeify(M, dst)
+    src_tree = Trees.treeify(M, src)
+    cps = CR.get_all_candidate_pairs(tf, predicate_f, src_tree, dst_tree)
+    items = CR.work_items(op, cps)
+    nrows, ncols = CR.output_matrix_size(op, src_tree, dst_tree)
+    rows, cols, vals = CR._parallel_coo(style, op, items, src_tree, dst_tree, tf; npartitions = npart, progress = false)
+
+    nf = threaded ? 3 : 2   # fewer reps for the slow serial phases
+    t_tree = bestof(() -> (Trees.treeify(M, dst); Trees.treeify(M, src)), 3)
+    t_cand = bestof(() -> CR.get_all_candidate_pairs(tf, predicate_f, src_tree, dst_tree), nf)
+    t_coo  = bestof(() -> CR._parallel_coo(style, op, items, src_tree, dst_tree, tf; npartitions = npart, progress = false), nf)
+    t_sp   = bestof(() -> sparse(rows, cols, vals, nrows, ncols), 5)
+    t_area = bestof(() -> (CR.areas(M, dst, dst_tree); CR.areas(M, src, src_tree)), 3)
+    alloc_coo = @allocated CR._parallel_coo(style, op, items, src_tree, dst_tree, tf; npartitions = npart, progress = false)
+
+    total = t_tree + t_cand + t_coo + t_sp + t_area
+    return (; Ny, ncells_dst = nrows, ncells_src = ncols, ncand = length(cps), nnz = length(vals),
+        t_tree, t_cand, t_coo, t_sp, t_area, total, alloc_coo)
+end
+
+function report(r, label)
+    @printf("\n[%s]  Ny=%d  dst=%d src=%d  candidates=%d  nnz=%d\n",
+        label, r.Ny, r.ncells_dst, r.ncells_src, r.ncand, r.nnz)
+    pct(t) = 100 * t / r.total
+    for (name, t) in [("treeify", r.t_tree), ("candidate search", r.t_cand),
+                      ("COO assembly", r.t_coo), ("sparse build", r.t_sp), ("per-cell areas", r.t_area)]
+        @printf("   %-18s %8.1f ms   %5.1f%%\n", name, t * 1e3, pct(t))
+    end
+    @printf("   %-18s %8.1f ms\n", "TOTAL", r.total * 1e3)
+    @printf("   COO assembly allocs: %.1f MB\n", r.alloc_coo / 2^20)
+end
+
+println("Julia threads = ", Threads.nthreads())
+
+for Ny in (64, 128), th in (false, true)   # warm up both code paths at both sizes
+    p = oceananigans_pair(Ny)
+    CR.Regridder(M, p.dst, p.src; normalize = false, threaded = th)
+end
+
+for Ny in (64, 128)
+    report(phase_times(Ny; threaded = true),  "threaded Ny=$Ny")
+    report(phase_times(Ny; threaded = false), "serial   Ny=$Ny")
+end
+
+println("\n\n================ PROFILE: serial Regridder construction, Ny=128 ================")
+pair = oceananigans_pair(128)
+CR.Regridder(M, pair.dst, pair.src; normalize = false, threaded = false)
+Profile.clear()
+Profile.init(; n = 10^7, delay = 0.0007)
+Profile.@profile for _ in 1:3
+    CR.Regridder(M, pair.dst, pair.src; normalize = false, threaded = false)
+end
+Profile.print(; format = :flat, sortedby = :count, mincount = 25)

--- a/bench/publish.sh
+++ b/bench/publish.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
-# Publish benchmark graphs to the orphan `benchmark-assets` branch and post/update a single
-# sticky PR comment that embeds them inline. Uses ONLY the stock GITHUB_TOKEN
-# (contents:write + pull-requests:write) — no bot PAT or gist. Same-repo PRs only: fork PRs get
-# a read-only token, so the push/comment is skipped gracefully.
+# Publish benchmark graphs to a SEPARATE assets repo (JuliaGeo/JuliaGeoBenchmarkResults, branch
+# `ConservativeRegridding`) and post/update a single sticky PR comment that embeds them inline.
+# Hosting the PNG blobs outside the ConservativeRegridding repo keeps its git history free of
+# benchmark cruft.
 #
-# Required env: GH_TOKEN, GITHUB_REPOSITORY (owner/repo), PR_NUMBER, RUN_ID. Optional: BASE_LABEL.
+# The cross-repo push uses an SSH *deploy key* (secret BENCHMARK_ASSETS_DEPLOY_KEY) scoped with
+# write access to the assets repo only — the stock GITHUB_TOKEN is scoped to its own repo and
+# cannot push to another. The sticky comment is still posted to the CR repo via the stock GH_TOKEN
+# (pull-requests:write).
+#
+# Fork PRs receive neither the deploy-key secret nor a writable token, so the push and comment
+# degrade gracefully — the graphs remain downloadable as the run's uploaded artifact.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY (the CR repo, for the comment), PR_NUMBER, RUN_ID.
+# Optional env: BASE_LABEL, SSH_DEPLOY_KEY (absent on fork PRs → asset push skipped).
 set -uo pipefail
 
 : "${GH_TOKEN:?}"; : "${GITHUB_REPOSITORY:?}"; : "${PR_NUMBER:?}"; : "${RUN_ID:?}"
 BASE_LABEL="${BASE_LABEL:-base}"
 RESULTS="bench/results"
-ASSET_BRANCH="benchmark-assets"
+ASSET_REPO="JuliaGeo/JuliaGeoBenchmarkResults"   # public cross-repo image host
+ASSET_BRANCH="ConservativeRegridding"            # one branch per package in the shared repo
 ASSET_DIR="pr-${PR_NUMBER}"
 MARKER="<!-- conservativeregridding-benchmarks -->"
 
@@ -18,27 +28,40 @@ shopt -s nullglob
 pngs=("$RESULTS"/*.png)
 if [ ${#pngs[@]} -eq 0 ]; then echo "no graphs to publish"; exit 0; fi
 
-# --- push graphs to the orphan asset branch, under a per-PR subdir ---------------------------
-remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-tmp="$(mktemp -d)"
-if git clone --quiet --depth 1 --branch "$ASSET_BRANCH" "$remote" "$tmp" 2>/dev/null; then
-    echo "cloned existing $ASSET_BRANCH"
+# --- push graphs to the assets repo (SSH deploy key), under a per-PR subdir -------------------
+PUBLISHED=0
+if [ -z "${SSH_DEPLOY_KEY:-}" ]; then
+    echo "BENCHMARK_ASSETS_DEPLOY_KEY not present (fork PR?) — skipping asset push"
 else
-    git clone --quiet --depth 1 "$remote" "$tmp"
-    git -C "$tmp" checkout --orphan "$ASSET_BRANCH"
-    git -C "$tmp" rm -rqf . >/dev/null 2>&1 || true
+    keyfile="$(mktemp)"; printf '%s\n' "$SSH_DEPLOY_KEY" > "$keyfile"; chmod 600 "$keyfile"
+    export GIT_SSH_COMMAND="ssh -i $keyfile -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+    remote="git@github.com:${ASSET_REPO}.git"
+    tmp="$(mktemp -d)"
+    if git clone --quiet --depth 1 --branch "$ASSET_BRANCH" "$remote" "$tmp" 2>/dev/null; then
+        echo "cloned ${ASSET_REPO}@${ASSET_BRANCH}"
+    else
+        # Branch missing on a fresh assets repo: start it as an orphan.
+        git clone --quiet --depth 1 "$remote" "$tmp"
+        git -C "$tmp" checkout --orphan "$ASSET_BRANCH"
+        git -C "$tmp" rm -rqf . >/dev/null 2>&1 || true
+    fi
+    mkdir -p "$tmp/$ASSET_DIR"
+    cp "$RESULTS"/*.png "$tmp/$ASSET_DIR/"
+    git -C "$tmp" add -A
+    git -C "$tmp" -c user.name="github-actions[bot]" \
+        -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+        commit --quiet -m "ConservativeRegridding PR #${PR_NUMBER} benchmark graphs (run ${RUN_ID})" \
+        || echo "no new graph bytes to commit"
+    if git -C "$tmp" push --quiet origin "$ASSET_BRANCH"; then
+        PUBLISHED=1
+        echo "published to ${ASSET_REPO}@${ASSET_BRANCH}/${ASSET_DIR}"
+    else
+        echo "WARNING: push to ${ASSET_REPO} failed"
+    fi
 fi
-mkdir -p "$tmp/$ASSET_DIR"
-cp "$RESULTS"/*.png "$tmp/$ASSET_DIR/"
-git -C "$tmp" add -A
-git -C "$tmp" -c user.name="github-actions[bot]" \
-    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-    commit --quiet -m "Benchmark graphs for PR #${PR_NUMBER} (run ${RUN_ID})" \
-    && git -C "$tmp" push --quiet origin "$ASSET_BRANCH" \
-    || echo "nothing to push (no graph changes)"
 
 # --- compose the comment with inline, cache-busted images ------------------------------------
-raw="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_BRANCH}/${ASSET_DIR}"
+raw="https://raw.githubusercontent.com/${ASSET_REPO}/${ASSET_BRANCH}/${ASSET_DIR}"
 runurl="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
 body="$(mktemp)"
 {
@@ -47,19 +70,24 @@ body="$(mktemp)"
     echo
     echo "> Shared CI runners are noisy — treat small differences as noise. [Full-resolution graphs are attached to the run as an artifact.](${runurl})"
     echo
-    if [ -f "$RESULTS/pr_vs_master.png" ]; then
-        echo "### Regridder construction: this PR vs \`${BASE_LABEL}\`"
-        echo "![pr vs base](${raw}/pr_vs_master.png?v=${RUN_ID})"
-        echo
-    fi
-    if [ -f "$RESULTS/scaling.png" ]; then
-        echo "### Construction scaling by grid family"
-        echo "![scaling](${raw}/scaling.png?v=${RUN_ID})"
-        echo
-    fi
-    if [ -f "$RESULTS/xesmf.png" ]; then
-        echo "### ConservativeRegridding vs XESMF (Oceananigans)"
-        echo "![xesmf](${raw}/xesmf.png?v=${RUN_ID})"
+    if [ "$PUBLISHED" = 1 ]; then
+        if [ -f "$RESULTS/pr_vs_master.png" ]; then
+            echo "### Regridder construction: this PR vs \`${BASE_LABEL}\`"
+            echo "![pr vs base](${raw}/pr_vs_master.png?v=${RUN_ID})"
+            echo
+        fi
+        if [ -f "$RESULTS/scaling.png" ]; then
+            echo "### Construction scaling by grid family"
+            echo "![scaling](${raw}/scaling.png?v=${RUN_ID})"
+            echo
+        fi
+        if [ -f "$RESULTS/xesmf.png" ]; then
+            echo "### ConservativeRegridding vs XESMF (Oceananigans)"
+            echo "![xesmf](${raw}/xesmf.png?v=${RUN_ID})"
+            echo
+        fi
+    else
+        echo "_Graphs were not published to the assets repo on this run (no deploy key — e.g. a fork PR); see the artifact linked above._"
         echo
     fi
     if [ -f "$RESULTS/summary.md" ]; then

--- a/bench/publish.sh
+++ b/bench/publish.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Publish benchmark graphs to the orphan `benchmark-assets` branch and post/update a single
+# sticky PR comment that embeds them inline. Uses ONLY the stock GITHUB_TOKEN
+# (contents:write + pull-requests:write) — no bot PAT or gist. Same-repo PRs only: fork PRs get
+# a read-only token, so the push/comment is skipped gracefully.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY (owner/repo), PR_NUMBER, RUN_ID. Optional: BASE_LABEL.
+set -uo pipefail
+
+: "${GH_TOKEN:?}"; : "${GITHUB_REPOSITORY:?}"; : "${PR_NUMBER:?}"; : "${RUN_ID:?}"
+BASE_LABEL="${BASE_LABEL:-base}"
+RESULTS="bench/results"
+ASSET_BRANCH="benchmark-assets"
+ASSET_DIR="pr-${PR_NUMBER}"
+MARKER="<!-- conservativeregridding-benchmarks -->"
+
+shopt -s nullglob
+pngs=("$RESULTS"/*.png)
+if [ ${#pngs[@]} -eq 0 ]; then echo "no graphs to publish"; exit 0; fi
+
+# --- push graphs to the orphan asset branch, under a per-PR subdir ---------------------------
+remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+tmp="$(mktemp -d)"
+if git clone --quiet --depth 1 --branch "$ASSET_BRANCH" "$remote" "$tmp" 2>/dev/null; then
+    echo "cloned existing $ASSET_BRANCH"
+else
+    git clone --quiet --depth 1 "$remote" "$tmp"
+    git -C "$tmp" checkout --orphan "$ASSET_BRANCH"
+    git -C "$tmp" rm -rqf . >/dev/null 2>&1 || true
+fi
+mkdir -p "$tmp/$ASSET_DIR"
+cp "$RESULTS"/*.png "$tmp/$ASSET_DIR/"
+git -C "$tmp" add -A
+git -C "$tmp" -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+    commit --quiet -m "Benchmark graphs for PR #${PR_NUMBER} (run ${RUN_ID})" \
+    && git -C "$tmp" push --quiet origin "$ASSET_BRANCH" \
+    || echo "nothing to push (no graph changes)"
+
+# --- compose the comment with inline, cache-busted images ------------------------------------
+raw="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${ASSET_BRANCH}/${ASSET_DIR}"
+runurl="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}"
+body="$(mktemp)"
+{
+    echo "$MARKER"
+    echo "## Benchmark results"
+    echo
+    echo "> Shared CI runners are noisy — treat small differences as noise. [Full-resolution graphs are attached to the run as an artifact.](${runurl})"
+    echo
+    if [ -f "$RESULTS/pr_vs_master.png" ]; then
+        echo "### Regridder construction: this PR vs \`${BASE_LABEL}\`"
+        echo "![pr vs base](${raw}/pr_vs_master.png?v=${RUN_ID})"
+        echo
+    fi
+    if [ -f "$RESULTS/scaling.png" ]; then
+        echo "### Construction scaling by grid family"
+        echo "![scaling](${raw}/scaling.png?v=${RUN_ID})"
+        echo
+    fi
+    if [ -f "$RESULTS/xesmf.png" ]; then
+        echo "### ConservativeRegridding vs XESMF (Oceananigans)"
+        echo "![xesmf](${raw}/xesmf.png?v=${RUN_ID})"
+        echo
+    fi
+    if [ -f "$RESULTS/summary.md" ]; then
+        echo "<details><summary>Construction-time table (PR vs ${BASE_LABEL})</summary>"
+        echo
+        cat "$RESULTS/summary.md"
+        echo
+        echo "</details>"
+    fi
+} > "$body"
+
+# --- upsert the sticky comment (find by hidden marker) ---------------------------------------
+cid="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+    --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" 2>/dev/null | head -n1)"
+if [ -n "${cid:-}" ]; then
+    gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${cid}" -F body=@"$body" >/dev/null \
+        && echo "updated sticky comment ${cid}"
+else
+    gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@"$body" >/dev/null \
+        && echo "posted sticky comment"
+fi

--- a/bench/run.jl
+++ b/bench/run.jl
@@ -1,0 +1,34 @@
+# Local entry point: run the full benchmark suite in the bench environment and write graphs +
+# a markdown summary to bench/results/.
+#
+#     julia --project=bench bench/run.jl [maxcells]
+#
+# Produces, under bench/results/:
+#     scaling.png  scaling.jls   — Part 1: construction scaling, Oceananigans + Healpix
+#     xesmf.png    xesmf.jls     — Part 2: ConservativeRegridding vs XESMF (Oceananigans)
+#
+# (The PR-vs-base comparison is compare.jl; it is what the CI runs.)
+
+include(joinpath(@__DIR__, "scaling.jl"))
+include(joinpath(@__DIR__, "xesmf.jl"))
+include(joinpath(@__DIR__, "plots.jl"))
+
+maxcells = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : typemax(Int)
+outdir = joinpath(@__DIR__, "results")
+mkpath(outdir)
+
+@info "Part 1: construction scaling" maxcells nthreads = Threads.nthreads()
+scaling_rows = run_scaling(; maxcells)
+Serialization.serialize(joinpath(outdir, "scaling.jls"), scaling_rows)
+plot_scaling(scaling_rows; path = joinpath(outdir, "scaling.png"))
+
+@info "Part 2: ConservativeRegridding vs XESMF"
+xesmf_rows = run_xesmf(; maxcells)
+Serialization.serialize(joinpath(outdir, "xesmf.jls"), xesmf_rows)
+plot_xesmf(xesmf_rows; path = joinpath(outdir, "xesmf.png"))
+
+println("\n## Construction scaling (ConservativeRegridding, threaded)\n")
+println(summary_markdown(scaling_rows))
+println("\n## ConservativeRegridding vs XESMF (Oceananigans)\n")
+println(xesmf_summary_markdown(xesmf_rows))
+@info "graphs written" dir = outdir

--- a/bench/scaling.jl
+++ b/bench/scaling.jl
@@ -1,0 +1,61 @@
+# Conda-free regridder-construction scaling benchmark across grid SIZE, for the two main grid
+# families (Oceananigans LatLon, Healpix). Imports NO CairoMakie and NO XESMF, so it runs in a
+# minimal environment — this is exactly what the two-ref CI runs, once per ref, in an isolated
+# subprocess (see compare.jl), with only the ConservativeRegridding package swapped.
+#
+#     julia --project=<env> bench/scaling.jl [out.jls] [maxcells]
+#
+# Emits a Vector of primitive-only NamedTuple rows via `Serialization` (so results round-trip
+# across processes / CR versions without deserializing any package-defined types) and prints
+# `pathof(ConservativeRegridding)` as a sentinel, so the active CR is provable in the logs.
+
+using ConservativeRegridding
+import GeometryOps as GO
+import SparseArrays
+using Chairmarks
+using Serialization
+
+include(joinpath(@__DIR__, "grids.jl"))
+
+# Build once (warm up compilation + record nnz), then time construction with Chairmarks.
+# `minimum` is the least-noisy estimator (BenchmarkTools convention) and needs no extra import.
+function bench_construction(pair; seconds = 5.0, threaded::Bool = true)
+    build() = ConservativeRegridding.Regridder(GO.Spherical(), pair.dst, pair.src;
+        normalize = false, threaded = threaded)
+    R = build()                                   # warm up + correctness + nnz
+    s = @be build() evals = 1 seconds = seconds   # Chairmarks Benchmark
+    best = minimum(s)
+    return (;
+        family     = pair.family,
+        method     = threaded ? "CR" : "CR-serial",
+        tier       = pair.tier,
+        ncells_dst = pair.ncells_dst,
+        ncells_src = pair.ncells_src,
+        nthreads   = Threads.nthreads(),
+        time_s     = best.time,
+        allocs     = Int(best.allocs),
+        bytes      = Int(best.bytes),
+        nnz        = SparseArrays.nnz(R.intersections),
+        nsamples   = length(s.samples),
+    )
+end
+
+function run_scaling(; maxcells = typemax(Int), seconds = 5.0, threaded::Bool = true)
+    pairs = vcat(oceananigans_tiers(; maxcells), healpix_tiers(; maxcells))
+    rows = NamedTuple[]
+    for p in pairs
+        @info "scaling" family = p.family tier = p.tier ncells_dst = p.ncells_dst
+        push!(rows, bench_construction(p; seconds, threaded))
+    end
+    return rows
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    out      = length(ARGS) >= 1 ? ARGS[1] : joinpath(@__DIR__, "results", "scaling.jls")
+    maxcells = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : typemax(Int)
+    @info "ConservativeRegridding source (sentinel)" path = pathof(ConservativeRegridding) nthreads = Threads.nthreads()
+    rows = run_scaling(; maxcells)
+    mkpath(dirname(out))
+    Serialization.serialize(out, rows)
+    @info "wrote scaling results" out nrows = length(rows)
+end

--- a/bench/scaling.jl
+++ b/bench/scaling.jl
@@ -12,19 +12,18 @@
 using ConservativeRegridding
 import GeometryOps as GO
 import SparseArrays
-using Chairmarks
 using Serialization
 
 include(joinpath(@__DIR__, "grids.jl"))
+include(joinpath(@__DIR__, "timing.jl"))
 
-# Build once (warm up compilation + record nnz), then time construction with Chairmarks.
-# `minimum` is the least-noisy estimator (BenchmarkTools convention) and needs no extra import.
-function bench_construction(pair; seconds = 5.0, threaded::Bool = true)
+# Build once (warm up compilation + record nnz), then time construction over several repetitions
+# (see timed_summary) so each point carries a median and an inter-quartile error band.
+function bench_construction(pair; reps::Int = 5, seconds_each::Float64 = 0.5, threaded::Bool = true)
     build() = ConservativeRegridding.Regridder(GO.Spherical(), pair.dst, pair.src;
         normalize = false, threaded = threaded)
     R = build()                                   # warm up + correctness + nnz
-    s = @be build() evals = 1 seconds = seconds   # Chairmarks Benchmark
-    best = minimum(s)
+    t = timed_summary(build; reps, seconds_each)
     return (;
         family     = pair.family,
         method     = threaded ? "CR" : "CR-serial",
@@ -32,20 +31,17 @@ function bench_construction(pair; seconds = 5.0, threaded::Bool = true)
         ncells_dst = pair.ncells_dst,
         ncells_src = pair.ncells_src,
         nthreads   = Threads.nthreads(),
-        time_s     = best.time,
-        allocs     = Int(best.allocs),
-        bytes      = Int(best.bytes),
+        t.time_s, t.time_lo, t.time_hi, t.nsamples, t.allocs, t.bytes,
         nnz        = SparseArrays.nnz(R.intersections),
-        nsamples   = length(s.samples),
     )
 end
 
-function run_scaling(; maxcells = typemax(Int), seconds = 5.0, threaded::Bool = true)
+function run_scaling(; maxcells = typemax(Int), reps::Int = 5, seconds_each::Float64 = 0.5, threaded::Bool = true)
     pairs = vcat(oceananigans_tiers(; maxcells), healpix_tiers(; maxcells))
     rows = NamedTuple[]
     for p in pairs
         @info "scaling" family = p.family tier = p.tier ncells_dst = p.ncells_dst
-        push!(rows, bench_construction(p; seconds, threaded))
+        push!(rows, bench_construction(p; reps, seconds_each, threaded))
     end
     return rows
 end

--- a/bench/timing.jl
+++ b/bench/timing.jl
@@ -1,0 +1,38 @@
+# Shared timing helper for the benchmark drivers.
+#
+# `timed_summary(build)` runs the zero-arg `build` closure over `reps` independent
+# repetitions; each repetition collects Chairmarks samples within a `seconds_each` budget and
+# every per-construction sample time is pooled. Because a repetition always yields at least one
+# sample, slow constructions still get >= `reps` independent measurements while fast ones get
+# many — enough, either way, to put error bars (the inter-quartile range) on each point.
+#
+# Returns primitive summary stats only (median + p25/p75 + sample count + min allocs/bytes), so
+# results stay trivially serializable across processes and package versions.
+#
+# (`using` is kept at top level, not inside a guard block: `@be` is a macro and must be in scope
+# when this file is lowered. Re-`include`ing is harmless — the `using` is idempotent and the
+# function is simply redefined.)
+
+using Chairmarks
+using Statistics
+
+function timed_summary(build; reps::Int = 5, seconds_each::Float64 = 0.5)
+    times = Float64[]
+    best = nothing                                   # min sample, for (deterministic) allocs/bytes
+    for _ in 1:reps
+        b = @be build() evals = 1 seconds = seconds_each
+        m = minimum(b)
+        best = (isnothing(best) || m.time < best.time) ? m : best
+        for smp in b.samples
+            push!(times, smp.time)
+        end
+    end
+    return (;
+        time_s   = median(times),
+        time_lo  = quantile(times, 0.25),
+        time_hi  = quantile(times, 0.75),
+        nsamples = length(times),
+        allocs   = Int(best.allocs),
+        bytes    = Int(best.bytes),
+    )
+end

--- a/bench/xesmf.jl
+++ b/bench/xesmf.jl
@@ -17,43 +17,43 @@
 using ConservativeRegridding
 import GeometryOps as GO
 import SparseArrays
-using Chairmarks
 using Serialization
 using Oceananigans: CenterField
 using XESMF
 
 include(joinpath(@__DIR__, "grids.jl"))
+include(joinpath(@__DIR__, "timing.jl"))
 
-function bench_cr(pair; threaded::Bool, seconds = 5.0)
+function bench_cr(pair; threaded::Bool, reps::Int = 5, seconds_each::Float64 = 0.5)
     build() = ConservativeRegridding.Regridder(GO.Spherical(), pair.dst, pair.src;
         normalize = false, threaded = threaded)
     R = build()
-    best = minimum(@be build() evals = 1 seconds = seconds)
+    t = timed_summary(build; reps, seconds_each)
     return (; family = "Oceananigans", method = threaded ? "CR" : "CR-serial", tier = pair.tier,
         ncells_dst = pair.ncells_dst, ncells_src = pair.ncells_src, nthreads = Threads.nthreads(),
-        time_s = best.time, allocs = Int(best.allocs), bytes = Int(best.bytes),
+        t.time_s, t.time_lo, t.time_hi, t.nsamples, t.allocs, t.bytes,
         nnz = SparseArrays.nnz(R.intersections))
 end
 
-function bench_xesmf(pair; seconds = 5.0)
+function bench_xesmf(pair; reps::Int = 5, seconds_each::Float64 = 0.5)
     dstf = CenterField(pair.dst)
     srcf = CenterField(pair.src)
     build() = XESMF.Regridder(dstf, srcf; method = "conservative")
     R = build()                                   # warm up: Python import + ESMF init + this shape
-    best = minimum(@be build() evals = 1 seconds = seconds)
+    t = timed_summary(build; reps, seconds_each)
     return (; family = "Oceananigans", method = "XESMF", tier = pair.tier,
         ncells_dst = pair.ncells_dst, ncells_src = pair.ncells_src, nthreads = Threads.nthreads(),
-        time_s = best.time, allocs = Int(best.allocs), bytes = Int(best.bytes),
+        t.time_s, t.time_lo, t.time_hi, t.nsamples, t.allocs, t.bytes,
         nnz = SparseArrays.nnz(R.weights))
 end
 
-function run_xesmf(; maxcells = typemax(Int), seconds = 5.0)
+function run_xesmf(; maxcells = typemax(Int), reps::Int = 5, seconds_each::Float64 = 0.5)
     rows = NamedTuple[]
     for pair in oceananigans_tiers(; maxcells)
         @info "xesmf-compare" tier = pair.tier ncells_dst = pair.ncells_dst
-        push!(rows, bench_cr(pair; threaded = true, seconds))
-        push!(rows, bench_cr(pair; threaded = false, seconds))
-        push!(rows, bench_xesmf(pair; seconds))
+        push!(rows, bench_cr(pair; threaded = true, reps, seconds_each))
+        push!(rows, bench_cr(pair; threaded = false, reps, seconds_each))
+        push!(rows, bench_xesmf(pair; reps, seconds_each))
     end
     return rows
 end

--- a/bench/xesmf.jl
+++ b/bench/xesmf.jl
@@ -1,0 +1,69 @@
+# ConservativeRegridding-vs-XESMF regridder CONSTRUCTION-time comparison, Oceananigans-only
+# (XESMF only supports Oceananigans fields via its extension). For each tier it times three
+# constructors:
+#
+#     CR          ConservativeRegridding.Regridder(...; threaded = true)   — pure-Julia assembly
+#     CR-serial   ConservativeRegridding.Regridder(...; threaded = false)  — single-threaded CR
+#     XESMF       XESMF.Regridder(dst_field, src_field; method)            — ESMF weight gen (Python)
+#
+# CR runs multithreaded by default; XESMF's weight generation is ESMF-controlled (typically
+# serial here). We therefore report BOTH CR threaded and CR serial so the comparison isn't a
+# misleading N-thread-vs-1-thread chart, and stamp `nthreads` into every row. XESMF's first call
+# pays PythonCall import + esmpy/ESMF init, so each workload is warmed up (built once, discarded)
+# before timing.
+#
+#     julia --project=bench bench/xesmf.jl [out.jls] [maxcells]
+
+using ConservativeRegridding
+import GeometryOps as GO
+import SparseArrays
+using Chairmarks
+using Serialization
+using Oceananigans: CenterField
+using XESMF
+
+include(joinpath(@__DIR__, "grids.jl"))
+
+function bench_cr(pair; threaded::Bool, seconds = 5.0)
+    build() = ConservativeRegridding.Regridder(GO.Spherical(), pair.dst, pair.src;
+        normalize = false, threaded = threaded)
+    R = build()
+    best = minimum(@be build() evals = 1 seconds = seconds)
+    return (; family = "Oceananigans", method = threaded ? "CR" : "CR-serial", tier = pair.tier,
+        ncells_dst = pair.ncells_dst, ncells_src = pair.ncells_src, nthreads = Threads.nthreads(),
+        time_s = best.time, allocs = Int(best.allocs), bytes = Int(best.bytes),
+        nnz = SparseArrays.nnz(R.intersections))
+end
+
+function bench_xesmf(pair; seconds = 5.0)
+    dstf = CenterField(pair.dst)
+    srcf = CenterField(pair.src)
+    build() = XESMF.Regridder(dstf, srcf; method = "conservative")
+    R = build()                                   # warm up: Python import + ESMF init + this shape
+    best = minimum(@be build() evals = 1 seconds = seconds)
+    return (; family = "Oceananigans", method = "XESMF", tier = pair.tier,
+        ncells_dst = pair.ncells_dst, ncells_src = pair.ncells_src, nthreads = Threads.nthreads(),
+        time_s = best.time, allocs = Int(best.allocs), bytes = Int(best.bytes),
+        nnz = SparseArrays.nnz(R.weights))
+end
+
+function run_xesmf(; maxcells = typemax(Int), seconds = 5.0)
+    rows = NamedTuple[]
+    for pair in oceananigans_tiers(; maxcells)
+        @info "xesmf-compare" tier = pair.tier ncells_dst = pair.ncells_dst
+        push!(rows, bench_cr(pair; threaded = true, seconds))
+        push!(rows, bench_cr(pair; threaded = false, seconds))
+        push!(rows, bench_xesmf(pair; seconds))
+    end
+    return rows
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    out      = length(ARGS) >= 1 ? ARGS[1] : joinpath(@__DIR__, "results", "xesmf.jls")
+    maxcells = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : typemax(Int)
+    @info "ConservativeRegridding source (sentinel)" path = pathof(ConservativeRegridding) nthreads = Threads.nthreads()
+    rows = run_xesmf(; maxcells)
+    mkpath(dirname(out))
+    Serialization.serialize(out, rows)
+    @info "wrote xesmf results" out nrows = length(rows)
+end


### PR DESCRIPTION
Adds regridder **construction-time** benchmarks and a label-gated CI job that graphs PR-vs-base construction time on the PR, modeled on Makie's benchmark workflow. Construction time is the focus (not regrid throughput).

## What's here (`bench/`)
- **Grid-scaling** (`scaling.jl`) — construction time vs grid **size** for the two main families, Oceananigans LatLon and Healpix; one curve per family. Conda-free.
- **CR vs XESMF** (`xesmf.jl`) — construction time vs XESMF/ESMF on Oceananigans grids (XESMF only supports Oceananigans). Times CR **threaded**, CR **serial**, and XESMF so the comparison isn't a misleading N-threads-vs-1 chart.
- **Plotting** (`plots.jl`) + local entry point (`run.jl`) → graphs in `bench/results/`.
- **Shared grid factories** (`grids.jl`): coarse→fine pairs (source at half the destination resolution), swept by size tier.

## PR-vs-base CI (`.github/workflows/benchmark.yml`)
Label-gated: add the **`run benchmarks`** label (or use *Run workflow*). The job:
1. `compare.jl` benchmarks the **PR** and the **base** ref — the driver always comes from the PR checkout, and only the `ConservativeRegridding` package is swapped (base via a detached git worktree; each ref runs in an isolated subprocess whose loaded package is provable via a `pathof` sentinel). Results are primitive-only `NamedTuple`s, so they cross the package-version boundary cleanly.
2. Runs CR-vs-XESMF on the PR ref (conda; isolated with `continue-on-error`).
3. Pushes the graphs to an orphan **`benchmark-assets`** branch and embeds them inline in a single **sticky PR comment**, using only the stock `GITHUB_TOKEN` — no bot PAT or gist. Full-res graphs also upload as a workflow artifact.

## Sample local results (4 Julia threads, cap 50k cells)

**Construction scaling** (lower is better) and **CR vs XESMF** — graphs will post to this PR once the `run benchmarks` label is added.

ConservativeRegridding vs XESMF (Oceananigans):

| dst cells | CR (threaded) | CR (serial) | XESMF | CR/XESMF |
|--:|--:|--:|--:|--:|
| 512 | 1.9 ms | 6.1 ms | 6.1 ms | 0.31× |
| 2048 | 8.5 ms | 27.2 ms | 17.3 ms | 0.49× |
| 8192 | 35.0 ms | 123.8 ms | 63.7 ms | 0.55× |
| 32768 | 160.6 ms | 535.2 ms | 260.2 ms | 0.62× |

(Threaded CR is ~1.6–3.2× faster than ESMF weight-gen; single-threaded, ESMF's Fortran path is faster than CR's serial assembly at scale.)

## Notes
- **Stacked on #110** (`as/parallelize-sparsematrix`) so this PR's diff is benchmark-only. Can be retargeted to `main`.
- Draft until the CI run is confirmed green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)