### PR TITLE
Use GeometryOps' SutherlandHodgmanCache in spherical intersection assembly

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1'
       - uses: julia-actions/cache@v3
 
       # --- Parts 1 & 4: conda-free PR-vs-base construction scaling (the common path) ----------

--- a/bench/compare.jl
+++ b/bench/compare.jl
@@ -33,7 +33,12 @@ function build_scaling_env(crpath)
     code = """
     using Pkg
     Pkg.develop(path = raw"$(crpath)")
-    Pkg.add(["Oceananigans", "Healpix", "Chairmarks", "GeometryOps"])
+    Pkg.add(["Oceananigans", "Healpix", "Chairmarks"])
+    # TEMPORARY (this PR only): the Sutherland-Hodgman allocation cache needs
+    # GeometryOps#as/cache-sutherlandhodgman; revert to registered GeometryOps
+    # once that branch is released. Both refs get the same GeometryOps, so the
+    # comparison isolates ConservativeRegridding's cache wiring.
+    Pkg.add(url = "https://github.com/JuliaGeo/GeometryOps.jl", rev = "as/cache-sutherlandhodgman")
     Pkg.instantiate()
     """
     run(`julia --startup-file=no --project=$(env) -e $(code)`)

--- a/src/ConservativeRegridding.jl
+++ b/src/ConservativeRegridding.jl
@@ -43,7 +43,7 @@ include("regridder/intersection_areas.jl")
 # Intersection-operator assembly interface (operators can plug into `intersection_areas`)
 @public intersection_areas, DefaultIntersectionOperator
 @public IntersectionReturnStyle, OutOfPlaceSingleResult, InPlace
-@public work_items, output_matrix_size
+@public work_items, output_matrix_size, task_local_operator
 
 """
     save_esmf_weights(path, regridder;

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -61,6 +61,16 @@ e.g. to group all of an element's candidate cells into one unit.
 work_items(::Any, candidate_pairs) = candidate_pairs
 
 """
+    task_local_operator(op) -> op′
+
+Return the operator instance one assembly task should use. Called once per chunk
+inside the parallel COO assembly (never in the per-item hot loop), so operators
+holding mutable per-task state — e.g. allocation caches — can hand each task a
+private copy. Defaults to returning `op` unchanged.
+"""
+task_local_operator(op) = op
+
+"""
     output_matrix_size(op, src_tree, dst_tree) -> (nrows, ncols)
 
 Shape of the sparse matrix [`intersection_areas`](@ref) assembles for `op`.
@@ -126,7 +136,15 @@ end
 end
 
 # One chunk of work items → its COO triplets. `style` is passed in, not re-resolved.
+# `task_local_operator`'s return type may not be inferrable (e.g. it can depend on
+# the loaded GeometryOps), so resolve the per-task operator here and pay one dynamic
+# dispatch per chunk into the type-stable kernel below — never one per item.
 function _assemble_chunk(style, op, items, src_tree, dst_tree)
+    chunk_op = task_local_operator(op)
+    return _assemble_chunk_kernel(style, chunk_op, items, src_tree, dst_tree)
+end
+
+function _assemble_chunk_kernel(style, op, items, src_tree, dst_tree)
     rows = Int[]
     cols = Int[]
     vals = Float64[]
@@ -176,11 +194,12 @@ Assemble the sparse intersection matrix between `src_tree` and `dst_tree` on
 `manifold`. Lower-level assembly entry that intersection operators plug into;
 most users go through [`Regridder`](@ref)`(…; intersection_operator = …)`.
 
-Driven by three dispatched seams on `intersection_operator`, each defaulting to
+Driven by four dispatched seams on `intersection_operator`, each defaulting to
 the built-in area computation:
 - [`IntersectionReturnStyle`](@ref)`(op)` — how each work item's contribution is stored.
 - [`work_items`](@ref)`(op, candidate_pairs)` — the units of work iterated.
 - [`output_matrix_size`](@ref)`(op, src_tree, dst_tree)` — the `(nrows, ncols)` shape.
+- [`task_local_operator`](@ref)`(op)` — per-task operator copy (e.g. carrying a private cache).
 
 `threaded` is a `GeometryOpsCore.BoolsAsTypes` (`True()`/`False()`; convert via
 `booltype(::Bool)`). When threaded, work items are partitioned into `npartitions`

--- a/src/regridder/regridder.jl
+++ b/src/regridder/regridder.jl
@@ -79,10 +79,16 @@ Default intersection operator for the given manifold.
 
 Implemented for `Planar` and `Spherical` manifolds at the moment.
 Will dispatch to the appropriate intersection operator / algorithm based on the manifold.
+
+On `Spherical`, when the loaded GeometryOps provides `SutherlandHodgmanCache`,
+[`task_local_operator`](@ref) hands each assembly task a copy carrying a private
+clipping-buffer cache (caches must not be shared across tasks).
 """
-struct DefaultIntersectionOperator{M}
+struct DefaultIntersectionOperator{M, C}
     manifold::M
+    cache::C
 end
+DefaultIntersectionOperator(manifold) = DefaultIntersectionOperator(manifold, nothing)
 
 function (op::DefaultIntersectionOperator{<: GeometryOps.Planar})(p1, p2)
     intersection_polys = #=try; =#
@@ -94,12 +100,26 @@ function (op::DefaultIntersectionOperator{<: GeometryOps.Planar})(p1, p2)
 end
 
 function (op::DefaultIntersectionOperator{M})(p1, p2) where {M <: GeometryOps.Spherical}
+    alg = GeometryOps.ConvexConvexSutherlandHodgman(op.manifold)
     intersection_polys = #=try; =#
-        GeometryOps.intersection(GeometryOps.ConvexConvexSutherlandHodgman(op.manifold), p1, p2; target = GeoInterface.PolygonTrait())
+        _sutherland_hodgman_intersection(alg, p1, p2, op.cache)
     # catch
     #     throw(DefaultIntersectionFailureError(p1, p2, e))
     # end
     return GeometryOps.area(op.manifold, intersection_polys)
+end
+
+# Dispatch on the cache so the no-cache path never passes a `cache` keyword —
+# keeping the operator loadable against GeometryOps versions without one.
+_sutherland_hodgman_intersection(alg, p1, p2, ::Nothing) =
+    GeometryOps.intersection(alg, p1, p2; target = GeoInterface.PolygonTrait())
+_sutherland_hodgman_intersection(alg, p1, p2, cache) =
+    GeometryOps.intersection(alg, p1, p2; target = GeoInterface.PolygonTrait(), cache)
+
+function task_local_operator(op::DefaultIntersectionOperator{<: GeometryOps.Spherical})
+    isdefined(GeometryOps, :SutherlandHodgmanCache) || return op
+    cache = GeometryOps.SutherlandHodgmanCache(op.manifold)
+    return DefaultIntersectionOperator(op.manifold, cache)
 end
 
 function Regridder(dst, src; kwargs...)


### PR DESCRIPTION
Wires the Sutherland-Hodgman allocation cache from [GeometryOps#as/cache-sutherlandhodgman](https://github.com/JuliaGeo/GeometryOps.jl/tree/as/cache-sutherlandhodgman) into the regridder-construction hot loop, to characterize its performance impact.

## What

- New interface seam **`task_local_operator(op)`** (`@public`), called once per chunk in the parallel COO assembly so operators holding mutable per-task state (allocation caches) can hand each task a private copy.
- `DefaultIntersectionOperator` gains a `cache` field; on `Spherical` the hook attaches a fresh `SutherlandHodgmanCache` per task. Caches are not task-safe, hence per-task copies.
- Dispatch on the cache value (`::Nothing` vs cache) keeps the operator loadable against GeometryOps versions without the cache — it degrades to the existing no-cache path.
- The per-task operator is resolved behind a **function barrier**: its type may not be inferrable (depends on the loaded GeometryOps), so assembly pays one dynamic dispatch per chunk into a type-stable kernel, never one per candidate pair. (The naive version cost +2 allocs and a dynamic dispatch per pair — measurable.)
- `bench/compare.jl` **temporarily** pins GeometryOps to the cache branch for *both* refs, so the CI comparison isolates ConservativeRegridding's cache wiring. Revert to registered GeometryOps before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)