### PR TITLE
Let curvilinear grids carry their manifold through Regridder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- `GeometryOpsCore.best_manifold(::AbstractCurvilinearGrid)` returns the manifold the grid
-  was constructed with, and `Trees.treeify(manifold, ::AbstractCurvilinearGrid)` wraps an
-  already-constructed grid in a `TopDownQuadtreeCursor`. Together these let
-  `Regridder(dst, src)` accept a grid object directly and compute on the radius that grid
-  declares — e.g. `Regridder(CellBasedGrid(Spherical(; radius = R_authalic), points), src)`
-  — rather than having to restate the manifold in the three-argument constructor.
-  Where the manifold passed to `treeify` differs from the grid's own, the argument wins
-  and the grid is rebuilt onto it, sharing its geometry array rather than copying; the
-  grid's own declaration is the default that one-argument `treeify(grid)` resolves
-  through `best_manifold`. Guarding against an unintended surface stays with `Regridder`,
-  which compares its destination's manifold against its source's. Grid types outside this
-  package need a `Trees._rebuild_manifold` method to be coercible.
+- `best_manifold(::AbstractCurvilinearGrid)` and `Trees.treeify(manifold, ::AbstractCurvilinearGrid)`, so a grid can be passed straight to `Regridder(dst, src)` and computed on the manifold it declares — e.g. `Regridder(CellBasedGrid(Spherical(; radius = R_authalic), points), src)`.  A `manifold` passed to `treeify` overrides the grid's own, rebuilding it with ConstructionBase.
+- The grid types are ConstructionBase-compatible, so `setproperties(grid, (; manifold))` rebuilds a grid onto another manifold, sharing its geometry rather than copying.
 
 ### Changed
-- `Planar`/`Spherical` promotion in `Regridder(dst, src)` promotes to the spherical side's
-  own manifold, radius included, instead of only recognizing the default `Spherical()` and
-  collapsing to it. A planar grid paired with a sphere of non-default radius is therefore
-  no longer rejected as a manifold mismatch (whether the promoted pair can then be clipped
-  is unchanged — mixing lon/lat tuples with unit-sphere points is a separate limitation).
-- The "Destination and source manifolds must be the same" error now names which manifold
-  came from which side and explains how to declare one, since the common cause is a
-  *guessed* manifold (a bare point matrix defaults to `Spherical()`, i.e. the WGS84 mean
-  radius) meeting a declared one such as the authalic sphere.
+- **Breaking**: `Regridder(dst, src)` no longer promotes a `Planar`/`Spherical` mismatch to `Spherical` — any mismatch now throws, and the manifold to compute on must be passed explicitly as `Regridder(manifold, dst, src)`.
 
 ## v0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `GeometryOpsCore.best_manifold(::AbstractCurvilinearGrid)` returns the manifold the grid
+  was constructed with, and `Trees.treeify(manifold, ::AbstractCurvilinearGrid)` wraps an
+  already-constructed grid in a `TopDownQuadtreeCursor`. Together these let
+  `Regridder(dst, src)` accept a grid object directly and compute on the radius that grid
+  declares — e.g. `Regridder(CellBasedGrid(Spherical(; radius = R_authalic), points), src)`
+  — rather than having to restate the manifold in the three-argument constructor.
+  Where the manifold passed to `treeify` differs from the grid's own, the argument wins
+  and the grid is rebuilt onto it, sharing its geometry array rather than copying; the
+  grid's own declaration is the default that one-argument `treeify(grid)` resolves
+  through `best_manifold`. Guarding against an unintended surface stays with `Regridder`,
+  which compares its destination's manifold against its source's. Grid types outside this
+  package need a `Trees._rebuild_manifold` method to be coercible.
+
+### Changed
+- `Planar`/`Spherical` promotion in `Regridder(dst, src)` promotes to the spherical side's
+  own manifold, radius included, instead of only recognizing the default `Spherical()` and
+  collapsing to it. A planar grid paired with a sphere of non-default radius is therefore
+  no longer rejected as a manifold mismatch (whether the promoted pair can then be clipped
+  is unchanged — mixing lon/lat tuples with unit-sphere points is a separate limitation).
+- The "Destination and source manifolds must be the same" error now names which manifold
+  came from which side and explains how to declare one, since the common cause is a
+  *guessed* manifold (a bare point matrix defaults to `Spherical()`, i.e. the WGS84 mean
+  radius) meeting a declared one such as the authalic sphere.
+
 ## v0.2.7
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ projects = ["test", "docs", "bench", "lib/ConservativeRegriddingTestHelpers"]
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
@@ -42,6 +43,7 @@ ConservativeRegriddingRingGridsExt = "RingGrids"
 [compat]
 ChunkSplitters = "3"
 ClimaCore = "0.14.49"
+ConstructionBase = "1"
 DocStringExtensions = "0.8, 0.9"
 Extents = "0.1"
 GeoInterface = "1"

--- a/src/regridder/regridder.jl
+++ b/src/regridder/regridder.jl
@@ -66,13 +66,34 @@ function Regridder(dst, src; kwargs...)
     src_manifold = GOCore.best_manifold(src)
 
     manifold = if dst_manifold != src_manifold
-        # Implicitly promote to spherical
-        if dst_manifold == GO.Planar() && src_manifold == GO.Spherical()
-            GO.Spherical()
-        elseif dst_manifold == GO.Spherical() && src_manifold == GO.Planar()
-            GO.Spherical()
+        # Implicitly promote to spherical.  `Planar` on one side is the fallback for
+        # coordinates that declare no surface, not a claim that the grid is flat, so the
+        # `Spherical` side wins - and it wins whole, radius included.
+        if dst_manifold isa GO.Planar && src_manifold isa GO.Spherical
+            src_manifold
+        elseif dst_manifold isa GO.Spherical && src_manifold isa GO.Planar
+            dst_manifold
         else
-            error("Destination and source manifolds must be the same.  Got $dst_manifold and $src_manifold.")
+            error(
+                """
+                Destination and source manifolds must be the same.  Got $dst_manifold (destination) and $src_manifold (source).
+
+                Two spheres of different radii are a real difference, not a rounding one - areas
+                scale with R², so they cannot be mixed in a single regridder.
+
+                If one of these is not the manifold you meant, note that `best_manifold` *guesses*
+                for input that carries no manifold of its own: a bare matrix of `UnitSphericalPoint`s,
+                for instance, is assumed to be on `Spherical()`, whose radius is the WGS84 mean
+                radius ($(GO.Spherical().radius) m) - and the equal-area (authalic) sphere is a
+                different one.  Declare the manifold you want to compute on, either at the regridder:
+
+                    Regridder(manifold, dst, src)
+
+                or on the grid itself, which then carries it through `best_manifold`:
+
+                    Regridder(CellBasedGrid(manifold, points), src)
+                """
+            )
         end
     else
         dst_manifold

--- a/src/regridder/regridder.jl
+++ b/src/regridder/regridder.jl
@@ -65,41 +65,14 @@ function Regridder(dst, src; kwargs...)
     dst_manifold = GOCore.best_manifold(dst)
     src_manifold = GOCore.best_manifold(src)
 
-    manifold = if dst_manifold != src_manifold
-        # Implicitly promote to spherical.  `Planar` on one side is the fallback for
-        # coordinates that declare no surface, not a claim that the grid is flat, so the
-        # `Spherical` side wins - and it wins whole, radius included.
-        if dst_manifold isa GO.Planar && src_manifold isa GO.Spherical
-            src_manifold
-        elseif dst_manifold isa GO.Spherical && src_manifold isa GO.Planar
-            dst_manifold
-        else
-            error(
-                """
-                Destination and source manifolds must be the same.  Got $dst_manifold (destination) and $src_manifold (source).
+    # Manifolds are never promoted implicitly: `best_manifold` guesses for input that
+    # declares none, so a mismatch is as likely a bad guess as a deliberate mix.
+    dst_manifold == src_manifold || throw(ArgumentError("""
+    Destination and source manifolds must be the same.  Got $dst_manifold (destination) and $src_manifold (source).
 
-                Two spheres of different radii are a real difference, not a rounding one - areas
-                scale with R², so they cannot be mixed in a single regridder.
+    Pass the manifold to compute on explicitly: `Regridder(manifold, dst, src)`."""))
 
-                If one of these is not the manifold you meant, note that `best_manifold` *guesses*
-                for input that carries no manifold of its own: a bare matrix of `UnitSphericalPoint`s,
-                for instance, is assumed to be on `Spherical()`, whose radius is the WGS84 mean
-                radius ($(GO.Spherical().radius) m) - and the equal-area (authalic) sphere is a
-                different one.  Declare the manifold you want to compute on, either at the regridder:
-
-                    Regridder(manifold, dst, src)
-
-                or on the grid itself, which then carries it through `best_manifold`:
-
-                    Regridder(CellBasedGrid(manifold, points), src)
-                """
-            )
-        end
-    else
-        dst_manifold
-    end
-
-    return Regridder(manifold, dst, src; kwargs...)
+    return Regridder(dst_manifold, dst, src; kwargs...)
 end
 
 function Regridder(

--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -39,6 +39,8 @@ struct ExplicitPolygonGrid{M <: GOCore.Manifold, PolyMatrixType <: AbstractMatri
     polygons::PolyMatrixType
 end
 GOCore.manifold(grid::ExplicitPolygonGrid) = grid.manifold
+_rebuild_manifold(grid::ExplicitPolygonGrid, manifold::GOCore.Manifold) =
+    ExplicitPolygonGrid(manifold, grid.polygons)
 
 ExplicitPolygonGrid(polygons::AbstractMatrix) = ExplicitPolygonGrid(GO.Planar(), polygons)
 
@@ -67,6 +69,8 @@ function CellBasedGrid(points::AbstractMatrix)
 end
 
 GOCore.manifold(grid::CellBasedGrid) = grid.manifold
+_rebuild_manifold(grid::CellBasedGrid, manifold::GOCore.Manifold) =
+    CellBasedGrid(manifold, grid.points)
 
 Base.@propagate_inbounds function getcell(grid::CellBasedGrid, i::Int, j::Int)
     @boundscheck begin
@@ -101,6 +105,8 @@ end
 RegularGrid(x, y) = RegularGrid(GO.Planar(), x, y)
 
 GOCore.manifold(grid::RegularGrid) = grid.manifold
+_rebuild_manifold(grid::RegularGrid, manifold::GOCore.Manifold) =
+    RegularGrid(manifold, grid.x, grid.y)
 
 ncells(quadtree::RegularGrid, dim::Int) = length(dim == 1 ? quadtree.x : quadtree.y) - 1
 function getcell(quadtree::RegularGrid, i::Int, j::Int)

--- a/src/trees/grids.jl
+++ b/src/trees/grids.jl
@@ -39,8 +39,6 @@ struct ExplicitPolygonGrid{M <: GOCore.Manifold, PolyMatrixType <: AbstractMatri
     polygons::PolyMatrixType
 end
 GOCore.manifold(grid::ExplicitPolygonGrid) = grid.manifold
-_rebuild_manifold(grid::ExplicitPolygonGrid, manifold::GOCore.Manifold) =
-    ExplicitPolygonGrid(manifold, grid.polygons)
 
 ExplicitPolygonGrid(polygons::AbstractMatrix) = ExplicitPolygonGrid(GO.Planar(), polygons)
 
@@ -69,8 +67,6 @@ function CellBasedGrid(points::AbstractMatrix)
 end
 
 GOCore.manifold(grid::CellBasedGrid) = grid.manifold
-_rebuild_manifold(grid::CellBasedGrid, manifold::GOCore.Manifold) =
-    CellBasedGrid(manifold, grid.points)
 
 Base.@propagate_inbounds function getcell(grid::CellBasedGrid, i::Int, j::Int)
     @boundscheck begin
@@ -105,8 +101,6 @@ end
 RegularGrid(x, y) = RegularGrid(GO.Planar(), x, y)
 
 GOCore.manifold(grid::RegularGrid) = grid.manifold
-_rebuild_manifold(grid::RegularGrid, manifold::GOCore.Manifold) =
-    RegularGrid(manifold, grid.x, grid.y)
 
 ncells(quadtree::RegularGrid, dim::Int) = length(dim == 1 ? quadtree.x : quadtree.y) - 1
 function getcell(quadtree::RegularGrid, i::Int, j::Int)

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -15,6 +15,7 @@ thing that is returned implements the `SpatialTreeInterface` methods.
 import GeometryOpsCore as GOCore
 import GeometryOps as GO
 import GeometryOps: SpatialTreeInterface as STI
+import ConstructionBase
 import Extents
 import SortTileRecursiveTree # in order to implement the `getcell/ncell` interface
 
@@ -166,66 +167,20 @@ and then you may also want to specialize on `STI.node_extent(::QuadtreeCursor{<:
 """
 abstract type AbstractCurvilinearGrid{M <: GOCore.Manifold} end
 
-#=
-### Manifolds and `treeify` for grids
-
-A curvilinear grid *carries* the manifold it was built on (`GOCore.manifold`, defined per
-grid type in `grids.jl`), so unlike a bare matrix of points there is nothing to guess -
-`best_manifold` is simply that declaration.  This is what lets a grid built on a
-non-default sphere, e.g. `CellBasedGrid(Spherical(; radius = R), points)`, carry `R`
-through `Regridder(dst, src)`, which resolves its compute manifold via `best_manifold`.
-
-(These live here, rather than up with the other `treeify` methods, because they dispatch
-on `AbstractCurvilinearGrid` - which only exists from this point in the file onwards.)
-=#
-
+# A grid carries the manifold it was built on, so there is nothing to guess.
 GOCore.best_manifold(grid::AbstractCurvilinearGrid) = GOCore.manifold(grid)
 
 """
     treeify(manifold::GOCore.Manifold, grid::AbstractCurvilinearGrid)
 
-Wrap an already-constructed grid in a [`Trees.TopDownQuadtreeCursor`](@ref), on `manifold`.
-
-A named `manifold` is an instruction, not an assertion: where it differs from the grid's
-own [`GOCore.manifold`](@ref) the argument wins and the grid is rebuilt onto it, sharing
-its geometry array rather than copying.  The rebuild is what keeps the tree
-self-consistent, since [`cell_range_extent`](@ref) dispatches on the grid's own manifold
-type - a coerced grid that still declared the old one would compute its node extents on a
-surface nobody asked for.
-
-The grid's declaration is therefore a *default*: it is what the one-argument
-`treeify(grid)` resolves through [`GOCore.best_manifold`](@ref) when no manifold is named.
-Guarding against an unintended surface belongs where two independently-derived manifolds
-meet - [`Regridder`](@ref) compares its destination's against its source's and refuses a
-mismatch - not here, where the caller has named one outright.
+Wrap `grid` in a [`Trees.TopDownQuadtreeCursor`](@ref), overriding the grid's own manifold
+with `manifold` if they differ.  The override rebuilds the grid via `ConstructionBase`,
+sharing its geometry rather than copying, since [`cell_range_extent`](@ref) dispatches on
+the grid's own manifold type.
 """
-function treeify(manifold::GOCore.Manifold, grid::AbstractCurvilinearGrid)
-    return TopDownQuadtreeCursor(_coerce_manifold(grid, manifold))
-end
-
-"""
-    _coerce_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold)
-
-`grid` rebuilt on `manifold`, sharing its geometry rather than copying it; `grid` itself
-when the manifold already matches, so the common path allocates nothing and preserves
-object identity.
-
-Each `AbstractCurvilinearGrid` needs a method: the geometry fields differ per type and
-there is no generic way to swap one field of an arbitrary struct without reaching for
-another dependency.
-"""
-_coerce_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold) =
-    GOCore.manifold(grid) === manifold ? grid : _rebuild_manifold(grid, manifold)
-
-function _rebuild_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold)
-    throw(ArgumentError("""
-    cannot rebuild a $(nameof(typeof(grid))) onto $manifold.
-
-    `treeify(manifold, grid)` coerces a grid onto the manifold it is given, which needs a \
-    `ConservativeRegridding.Trees._rebuild_manifold(::$(nameof(typeof(grid))), ::Manifold)` \
-    method returning the same grid on the new manifold. Define one, or build the grid on \
-    $manifold to begin with."""))
-end
+treeify(manifold::GOCore.Manifold, grid::AbstractCurvilinearGrid) = TopDownQuadtreeCursor(
+    GOCore.manifold(grid) === manifold ? grid : ConstructionBase.setproperties(grid, (; manifold))
+)
 
 """
     getcell(grid::AbstractCurvilinearGrid, i::Int, j::Int) -> GI.Polygon

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -166,6 +166,67 @@ and then you may also want to specialize on `STI.node_extent(::QuadtreeCursor{<:
 """
 abstract type AbstractCurvilinearGrid{M <: GOCore.Manifold} end
 
+#=
+### Manifolds and `treeify` for grids
+
+A curvilinear grid *carries* the manifold it was built on (`GOCore.manifold`, defined per
+grid type in `grids.jl`), so unlike a bare matrix of points there is nothing to guess -
+`best_manifold` is simply that declaration.  This is what lets a grid built on a
+non-default sphere, e.g. `CellBasedGrid(Spherical(; radius = R), points)`, carry `R`
+through `Regridder(dst, src)`, which resolves its compute manifold via `best_manifold`.
+
+(These live here, rather than up with the other `treeify` methods, because they dispatch
+on `AbstractCurvilinearGrid` - which only exists from this point in the file onwards.)
+=#
+
+GOCore.best_manifold(grid::AbstractCurvilinearGrid) = GOCore.manifold(grid)
+
+"""
+    treeify(manifold::GOCore.Manifold, grid::AbstractCurvilinearGrid)
+
+Wrap an already-constructed grid in a [`Trees.TopDownQuadtreeCursor`](@ref), on `manifold`.
+
+A named `manifold` is an instruction, not an assertion: where it differs from the grid's
+own [`GOCore.manifold`](@ref) the argument wins and the grid is rebuilt onto it, sharing
+its geometry array rather than copying.  The rebuild is what keeps the tree
+self-consistent, since [`cell_range_extent`](@ref) dispatches on the grid's own manifold
+type - a coerced grid that still declared the old one would compute its node extents on a
+surface nobody asked for.
+
+The grid's declaration is therefore a *default*: it is what the one-argument
+`treeify(grid)` resolves through [`GOCore.best_manifold`](@ref) when no manifold is named.
+Guarding against an unintended surface belongs where two independently-derived manifolds
+meet - [`Regridder`](@ref) compares its destination's against its source's and refuses a
+mismatch - not here, where the caller has named one outright.
+"""
+function treeify(manifold::GOCore.Manifold, grid::AbstractCurvilinearGrid)
+    return TopDownQuadtreeCursor(_coerce_manifold(grid, manifold))
+end
+
+"""
+    _coerce_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold)
+
+`grid` rebuilt on `manifold`, sharing its geometry rather than copying it; `grid` itself
+when the manifold already matches, so the common path allocates nothing and preserves
+object identity.
+
+Each `AbstractCurvilinearGrid` needs a method: the geometry fields differ per type and
+there is no generic way to swap one field of an arbitrary struct without reaching for
+another dependency.
+"""
+_coerce_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold) =
+    GOCore.manifold(grid) === manifold ? grid : _rebuild_manifold(grid, manifold)
+
+function _rebuild_manifold(grid::AbstractCurvilinearGrid, manifold::GOCore.Manifold)
+    throw(ArgumentError("""
+    cannot rebuild a $(nameof(typeof(grid))) onto $manifold.
+
+    `treeify(manifold, grid)` coerces a grid onto the manifold it is given, which needs a \
+    `ConservativeRegridding.Trees._rebuild_manifold(::$(nameof(typeof(grid))), ::Manifold)` \
+    method returning the same grid on the new manifold. Define one, or build the grid on \
+    $manifold to begin with."""))
+end
+
 """
     getcell(grid::AbstractCurvilinearGrid, i::Int, j::Int) -> GI.Polygon
     getcell(grid::AbstractCurvilinearGrid, idx::Integer) -> GI.Polygon

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ConservativeRegridding = "8e50ac2c-eb48-49bc-a402-07c87b949343"
 ConservativeRegriddingTestHelpers = "883fd9f3-db67-4942-a9f0-94e65a04ba8b"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeometryOps = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"

--- a/test/trees/grids.jl
+++ b/test/trees/grids.jl
@@ -269,3 +269,93 @@ end
         @test length(it) == 2 * (imax - imin + 1) + 2 * (jmax - jmin + 1) - 4
     end
 end
+
+# ===========================================================================
+# Declared manifolds. A grid carries the manifold it was built on, so
+# `best_manifold` reports it verbatim and `Regridder(dst, src)` computes on it -
+# no need for the caller to restate it in a three-argument constructor.
+#
+# The radius is the point: the WGS84 *authalic* (equal-area) sphere below is
+# 1.6 m smaller than `Spherical()`'s mean radius, i.e. ~5e-7 in area, so a grid
+# whose radius silently reverted to the default would show up in the invariants.
+# ===========================================================================
+
+const _AUTHALIC = GOCore.Spherical(; radius = 6371007.180918474)   # WGS84 R_A
+
+_authalic_corners(nlon, nlat) = [
+    GO.UnitSphereFromGeographic()((lon, lat))
+    for lon in range(-180, 180; length = nlon), lat in range(-90, 90; length = nlat)
+]
+
+@testset "best_manifold reports a grid's declared manifold" begin
+    points   = make_lonlat_point_matrix(4, 3)
+    polygons = make_polygon_matrix(points)
+
+    # The one-argument constructors keep guessing exactly as they always have.
+    @test GOCore.best_manifold(ExplicitPolygonGrid(polygons)) == GOCore.Planar()
+    @test GOCore.best_manifold(CellBasedGrid(points)) == GOCore.Planar()
+    @test GOCore.best_manifold(CellBasedGrid(_SPH_PTS)) == GOCore.Spherical()
+    @test GOCore.best_manifold(RegularGrid(_SPH_LONS, _SPH_LATS)) == GOCore.Planar()
+
+    # A declared manifold is reported verbatim, radius and all.
+    for grid in (ExplicitPolygonGrid(_AUTHALIC, polygons),
+                 CellBasedGrid(_AUTHALIC, _SPH_PTS),
+                 RegularGrid(_AUTHALIC, _SPH_LONS, _SPH_LATS))
+        @test GOCore.best_manifold(grid) == GOCore.manifold(grid) == _AUTHALIC
+    end
+end
+
+@testset "treeify coerces the grid onto the manifold it is given" begin
+    treeify = ConservativeRegridding.Trees.treeify
+    grid = CellBasedGrid(_AUTHALIC, _SPH_PTS)
+
+    # One-argument `treeify` routes through `best_manifold`, so the grid's own
+    # declaration is what is used, and the grid is passed through untouched.
+    tree = treeify(grid)
+    @test tree isa TopDownQuadtreeCursor
+    @test ConservativeRegridding.Trees.getgrid(tree) === grid
+    @test GOCore.best_manifold(tree) == _AUTHALIC
+
+    # Naming the grid's own manifold is likewise a pass-through, not a rebuild.
+    @test ConservativeRegridding.Trees.getgrid(treeify(_AUTHALIC, grid)) === grid
+
+    # A named manifold that differs is an instruction, not a contradiction: the
+    # argument wins and the grid is rebuilt onto it, so the tree it produces is
+    # self-consistent (this is what `cell_range_extent` dispatches on).
+    for m in (GOCore.Spherical(), GOCore.Spherical(; radius = 1.0), GO.Planar())
+        coerced = treeify(m, grid)
+        @test coerced isa TopDownQuadtreeCursor
+        @test GOCore.manifold(ConservativeRegridding.Trees.getgrid(coerced)) === m
+        @test GOCore.best_manifold(coerced) === m
+        # Only the manifold moves — the geometry is the same array, not a copy.
+        @test ConservativeRegridding.Trees.getgrid(coerced).points === grid.points
+    end
+
+    # Coercion is defined for every grid type, not just CellBasedGrid.
+    for g in (ExplicitPolygonGrid(_AUTHALIC, make_polygon_matrix(_SPH_PTS)),
+              CellBasedGrid(_AUTHALIC, _SPH_PTS),
+              RegularGrid(_AUTHALIC, _SPH_LONS, _SPH_LATS))
+        coerced = treeify(GO.Planar(), g)
+        @test GOCore.manifold(ConservativeRegridding.Trees.getgrid(coerced)) === GO.Planar()
+    end
+end
+
+@testset "Regridder carries a declared radius end to end" begin
+    src = CellBasedGrid(_AUTHALIC, _authalic_corners(9, 5))
+    dst = CellBasedGrid(_AUTHALIC, _authalic_corners(7, 4))
+
+    r = ConservativeRegridding.Regridder(dst, src; normalize = false, threaded = false)
+    @test size(r) == (18, 32)
+
+    # Both grids tile the whole sphere, so areas and intersections sum to 4πR² -
+    # at the *declared* radius, not at `Spherical()`'s.
+    sphere = 4π * _AUTHALIC.radius^2
+    @test sum(r.intersections) ≈ sphere
+    @test sum(r.src_areas) ≈ sphere
+    @test sum(r.dst_areas) ≈ sphere
+    @test !isapprox(sphere, 4π * GOCore.Spherical().radius^2; rtol = 1e-8)  # the radii really do differ
+
+    # Two genuinely different spheres are still rejected, loudly.
+    dst_mean_radius = CellBasedGrid(GOCore.Spherical(), _authalic_corners(7, 4))
+    @test_throws "manifolds must be the same" ConservativeRegridding.Regridder(dst_mean_radius, src)
+end

--- a/test/trees/grids.jl
+++ b/test/trees/grids.jl
@@ -200,6 +200,7 @@ end
 # (replacing the private `_pt_at` accessor and the `PerimeterPoints` state machine).
 # ===========================================================================
 import GeometryOps as GO
+import ConstructionBase
 import LinearAlgebra
 
 # Regional spherical grids — chosen away from poles/antipodes so the bounding cap
@@ -270,16 +271,9 @@ end
     end
 end
 
-# ===========================================================================
-# Declared manifolds. A grid carries the manifold it was built on, so
-# `best_manifold` reports it verbatim and `Regridder(dst, src)` computes on it -
-# no need for the caller to restate it in a three-argument constructor.
-#
-# The radius is the point: the WGS84 *authalic* (equal-area) sphere below is
-# 1.6 m smaller than `Spherical()`'s mean radius, i.e. ~5e-7 in area, so a grid
-# whose radius silently reverted to the default would show up in the invariants.
-# ===========================================================================
-
+# Declared manifolds.  The WGS84 authalic (equal-area) sphere below is 1.6 m smaller than
+# `Spherical()`'s mean radius, so a radius that silently reverted to the default shows up
+# in the area invariants.
 const _AUTHALIC = GOCore.Spherical(; radius = 6371007.180918474)   # WGS84 R_A
 
 _authalic_corners(nlon, nlat) = [
@@ -297,7 +291,6 @@ _authalic_corners(nlon, nlat) = [
     @test GOCore.best_manifold(CellBasedGrid(_SPH_PTS)) == GOCore.Spherical()
     @test GOCore.best_manifold(RegularGrid(_SPH_LONS, _SPH_LATS)) == GOCore.Planar()
 
-    # A declared manifold is reported verbatim, radius and all.
     for grid in (ExplicitPolygonGrid(_AUTHALIC, polygons),
                  CellBasedGrid(_AUTHALIC, _SPH_PTS),
                  RegularGrid(_AUTHALIC, _SPH_LONS, _SPH_LATS))
@@ -305,38 +298,50 @@ _authalic_corners(nlon, nlat) = [
     end
 end
 
-@testset "treeify coerces the grid onto the manifold it is given" begin
+@testset "grids are ConstructionBase-compatible" begin
+    # `setproperties` is what `treeify`'s manifold override is built on.
+    cbg = ConstructionBase.setproperties(CellBasedGrid(_AUTHALIC, _SPH_PTS), (; manifold = GO.Planar()))
+    @test GOCore.manifold(cbg) === GO.Planar()
+    @test cbg.points === _SPH_PTS               # geometry shared, not copied
+
+    polygons = make_polygon_matrix(_SPH_PTS)
+    epg = ConstructionBase.setproperties(ExplicitPolygonGrid(_AUTHALIC, polygons), (; manifold = GO.Planar()))
+    @test GOCore.manifold(epg) === GO.Planar()
+    @test epg.polygons === polygons
+
+    rg = ConstructionBase.setproperties(RegularGrid(_AUTHALIC, _SPH_LONS, _SPH_LATS), (; manifold = GO.Planar()))
+    @test GOCore.manifold(rg) === GO.Planar()
+    @test rg.x === _SPH_LONS && rg.y === _SPH_LATS
+end
+
+@testset "treeify overrides the grid's manifold with the one it is given" begin
     treeify = ConservativeRegridding.Trees.treeify
+    getgrid = ConservativeRegridding.Trees.getgrid
     grid = CellBasedGrid(_AUTHALIC, _SPH_PTS)
 
-    # One-argument `treeify` routes through `best_manifold`, so the grid's own
-    # declaration is what is used, and the grid is passed through untouched.
+    # One-argument `treeify` routes through `best_manifold`, i.e. the grid's own.
     tree = treeify(grid)
     @test tree isa TopDownQuadtreeCursor
-    @test ConservativeRegridding.Trees.getgrid(tree) === grid
+    @test getgrid(tree) === grid
     @test GOCore.best_manifold(tree) == _AUTHALIC
 
-    # Naming the grid's own manifold is likewise a pass-through, not a rebuild.
-    @test ConservativeRegridding.Trees.getgrid(treeify(_AUTHALIC, grid)) === grid
+    # Naming the grid's own manifold is a pass-through, not a rebuild.
+    @test getgrid(treeify(_AUTHALIC, grid)) === grid
 
-    # A named manifold that differs is an instruction, not a contradiction: the
-    # argument wins and the grid is rebuilt onto it, so the tree it produces is
-    # self-consistent (this is what `cell_range_extent` dispatches on).
+    # A different manifold overrides the grid's own, so the tree stays self-consistent
+    # (this is what `cell_range_extent` dispatches on).
     for m in (GOCore.Spherical(), GOCore.Spherical(; radius = 1.0), GO.Planar())
-        coerced = treeify(m, grid)
-        @test coerced isa TopDownQuadtreeCursor
-        @test GOCore.manifold(ConservativeRegridding.Trees.getgrid(coerced)) === m
-        @test GOCore.best_manifold(coerced) === m
-        # Only the manifold moves — the geometry is the same array, not a copy.
-        @test ConservativeRegridding.Trees.getgrid(coerced).points === grid.points
+        overridden = treeify(m, grid)
+        @test overridden isa TopDownQuadtreeCursor
+        @test GOCore.manifold(getgrid(overridden)) === m
+        @test GOCore.best_manifold(overridden) === m
+        @test getgrid(overridden).points === grid.points   # geometry shared, not copied
     end
 
-    # Coercion is defined for every grid type, not just CellBasedGrid.
     for g in (ExplicitPolygonGrid(_AUTHALIC, make_polygon_matrix(_SPH_PTS)),
               CellBasedGrid(_AUTHALIC, _SPH_PTS),
               RegularGrid(_AUTHALIC, _SPH_LONS, _SPH_LATS))
-        coerced = treeify(GO.Planar(), g)
-        @test GOCore.manifold(ConservativeRegridding.Trees.getgrid(coerced)) === GO.Planar()
+        @test GOCore.manifold(getgrid(treeify(GO.Planar(), g))) === GO.Planar()
     end
 end
 
@@ -348,14 +353,26 @@ end
     @test size(r) == (18, 32)
 
     # Both grids tile the whole sphere, so areas and intersections sum to 4πR² -
-    # at the *declared* radius, not at `Spherical()`'s.
+    # at the declared radius, not at `Spherical()`'s.
     sphere = 4π * _AUTHALIC.radius^2
     @test sum(r.intersections) ≈ sphere
     @test sum(r.src_areas) ≈ sphere
     @test sum(r.dst_areas) ≈ sphere
     @test !isapprox(sphere, 4π * GOCore.Spherical().radius^2; rtol = 1e-8)  # the radii really do differ
+end
 
-    # Two genuinely different spheres are still rejected, loudly.
+@testset "Regridder refuses to guess between two manifolds" begin
+    src = CellBasedGrid(_AUTHALIC, _authalic_corners(9, 5))
+
+    # Two spheres of different radii.
     dst_mean_radius = CellBasedGrid(GOCore.Spherical(), _authalic_corners(7, 4))
     @test_throws "manifolds must be the same" ConservativeRegridding.Regridder(dst_mean_radius, src)
+
+    # Planar against spherical is no longer promoted to spherical either.
+    dst_planar = CellBasedGrid(GO.Planar(), _authalic_corners(7, 4))
+    @test_throws "Regridder(manifold, dst, src)" ConservativeRegridding.Regridder(dst_planar, src)
+
+    # Naming the manifold is what gets you past it.
+    r = ConservativeRegridding.Regridder(_AUTHALIC, dst_planar, src; normalize = false, threaded = false)
+    @test sum(r.intersections) ≈ 4π * _AUTHALIC.radius^2
 end


### PR DESCRIPTION
## The problem

A grid built on a non-default sphere couldn't be handed to `Regridder`:

```julia
R_authalic = 6371007.180918474        # WGS84 equal-area radius
grid = CellBasedGrid(Spherical(; radius = R_authalic), points)
Regridder(grid, src)
#=> MethodError: no method matching best_manifold(::CellBasedGrid{…})
```

`ExplicitPolygonGrid`, `CellBasedGrid` and `RegularGrid` all store the manifold they were
built on and define `GOCore.manifold`, but nothing defined `best_manifold` for them, and
there is no catch-all `best_manifold` method to fall back on.

Adding only `best_manifold` would have moved the failure one step later: there was no
`treeify` method for `AbstractCurvilinearGrid` either, and a grid matches none of the
generic `treeify(manifold, grid)` branches — `isspatialtree` is `false`, it isn't an
`AbstractMatrix`, and `Base.isiterable` is `false` — so it falls through and returns
`nothing`.

## The change

Three methods and a dependency.

**`best_manifold(::AbstractCurvilinearGrid)`** returns the grid's own declaration.  Unlike a
bare point matrix, a grid has nothing to guess.

**`treeify(manifold, ::AbstractCurvilinearGrid)`** wraps the grid in a
`TopDownQuadtreeCursor`.  A `manifold` argument that differs from the grid's own overrides
it — an explicit override for development, testing, and users who want one — rebuilding the
grid with `ConstructionBase.setproperties`, sharing its geometry array rather than copying.
The rebuild is what keeps the tree self-consistent: `cell_range_extent` dispatches on the
grid's manifold *type parameter*, so a grid still declaring the old manifold would compute
node extents on a surface nobody asked for.

**`ConstructionBase` is now a dependency**, which is what lets that be one line.  The grid
structs needed no code to become compatible — they have plain default constructors, so the
default `setproperties` already rebuilds them — so `src/trees/grids.jl` is untouched by this
PR, and grid types outside this package are coercible for free as long as they have a
`manifold` field (the HEALPix and OctaHEALPix face grids in `ext/` do).

## Breaking change: no implicit manifold promotion

`Regridder(dst, src)` used to promote a `Planar`/`Spherical` mismatch to `Spherical()`.  It
no longer promotes anything: any mismatch throws an `ArgumentError` naming which manifold
came from each side and pointing at `Regridder(manifold, dst, src)`.

Two reasons this costs little in practice:

- The comparison was `== GO.Spherical()`, which recognizes only the default radius and
  collapsed any other sphere onto it — silently rescaling areas by `(R₁/R₂)²`.  Oceananigans
  already reports `Spherical(; radius = grid.radius)`.
- The pairing that promotion produced doesn't clip anyway, at any radius.  Handing a
  `(lons, lats)` grid and a `UnitSphericalPoint` grid to `Regridder(Spherical(), dst, src)`
  today throws `DimensionMismatch: No precise constructor for UnitSphericalPoint{Float64}
  found. Length of input was 2.` — so promotion was turning a clear manifold error into an
  obscure one downstream.

Callers pairing two grids that genuinely share a surface are unaffected; every mixed-manifold
call site in the test suite either pins matching radii or already passes the manifold
explicitly.

## Tests

40 new assertions in `test/trees/grids.jl`:

- `best_manifold` on all three grid types, asserting the one-argument constructor defaults
  are **unchanged**.
- `ConstructionBase.setproperties` round-trips each grid type onto a new manifold with
  geometry identity (`===`) preserved.
- `treeify` pass-through when the manifold matches, and override when it doesn't, for each
  grid type.
- End-to-end `Regridder` on the authalic sphere:
  `sum(intersections) ≈ sum(src_areas) ≈ sum(dst_areas) ≈ 4πR_A²`.  The authalic radius is
  1.6 m off `Spherical()`'s mean radius, so a radius that silently reverted to the default
  would show up here.
- Both a two-sphere mismatch and a planar/spherical pair are rejected, and
  `Regridder(manifold, dst, src)` gets you past it.

Full suite green on CI (Julia 1 and 1.11): **10022 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
