### PR TITLE
Update ConservativeRegriddingClimaCoreExt to use ClimaCore 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.8
+
+### Changed
+- ClimaCore extension updated for ClimaCore 0.15: nodal flatten/copy and Jacobian
+  access now use DataLayout `(v, i, j, h)` indexing / `Fields.field2array` instead of
+  the removed `DataLayouts.data2array` and 4-D `parent(...)` IJFH indexing.
+- ClimaCore weak-dependency compat bumped from `0.14` to `0.15`.
+
 ## v0.2.7
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConservativeRegridding"
 uuid = "8e50ac2c-eb48-49bc-a402-07c87b949343"
 license = "MIT"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com>", "Milan Kloewer <milankloewer@gmx.de>", "Simone Silvestri <silvestri.simone0@gmail.com>", "and contributors"]
 
 [workspace]
@@ -41,7 +41,7 @@ ConservativeRegriddingRingGridsExt = "RingGrids"
 
 [compat]
 ChunkSplitters = "3"
-ClimaCore = "0.14.49"
+ClimaCore = "0.15.0"
 DocStringExtensions = "0.8, 0.9"
 Extents = "0.1"
 GeoInterface = "1"

--- a/ext/ConservativeRegriddingClimaCoreExt.jl
+++ b/ext/ConservativeRegriddingClimaCoreExt.jl
@@ -101,20 +101,17 @@ Trees.treeify(manifold::GOCore.Spherical, field::ClimaCore.Fields.Field) = Trees
 """
     flat_nodal_data(data::DataLayouts.AbstractData) → Vector
 
-Flatten nodal storage to a `Vector` via [`DataLayouts.data2array`](@ref) (memory layout:
-for `IJFH`, `i` fastest, then `j`, then horizontal indices). For layouts with a vertical
-dimension (`VIJFH`, etc.) `data2array` is an ``N_v \\times N_h`` matrix; the first vertical
-level is taken. Unlike `Fields.field2array`, accepts raw `AbstractData` (e.g.
-`Fields.field_values(coords.lat)`, `Spaces.weighted_jacobian(space)`).
+Flatten nodal storage to a `Vector`. Parent arrays are always 5-D
+`(v, i, j, f, h)` with logical DataLayout indexing `(v, i, j, h)`. For multi-level data
+the first vertical level is taken. Unlike `Fields.field2array`, accepts raw `AbstractData`
+(e.g. `Fields.field_values(coords.lat)`, `Spaces.weighted_jacobian(space)`).
 """
 function flat_nodal_data(data::DataLayouts.AbstractData)
-    array = DataLayouts.data2array(data)
-    if array isa AbstractVector
-        return vec(array)
-    elseif ndims(array) == 2
-        return vec(view(array, 1, :))
+    Nv = DataLayouts.nlevels(data)
+    if Nv == 1
+        return vec(parent(data))
     else
-        error("Unexpected data2array shape: $(size(array))")
+        return vec(view(reshape(parent(data), Nv, :), 1, :))
     end
 end
 
@@ -198,11 +195,11 @@ values on `space`:
 
     Jᵉ(ξ, η) ≈ Σ_{p,q} Jᵉₚᵩ ϕₚ(ξ) ϕᵩ(η)
 
-where `Jᵉₚᵩ = WJ[p, q, 1, elem_idx] / (wₚ wᵩ)` is the unweighted Jacobian recovered from
-`Spaces.weighted_jacobian` storage. Used to evaluate the `Jᵉ` factor of the FV → SE local
-mass matrix at off-node quadrature points; the `B` weights themselves do not need it (see
-`accumulate_principled_b`). See the "FV → SE" section of
-`docs/src/extensions/climacore.md`.
+where `Jᵉₚᵩ = WJ[1, p, q, elem_idx] / (wₚ wᵩ)` is the unweighted Jacobian recovered from
+`Spaces.weighted_jacobian` storage (ClimaCore 0.15 DataLayout indexing `(v, i, j, h)`).
+Used to evaluate the `Jᵉ` factor of the FV → SE local mass matrix at off-node quadrature
+points; the `B` weights themselves do not need it (see `accumulate_principled_b`). See the
+"FV → SE" section of `docs/src/extensions/climacore.md`.
 """
 function element_jacobian_at(space::ClimaCore.Spaces.AbstractSpectralElementSpace,
                              elem_idx::Int, ξ, η)
@@ -210,13 +207,14 @@ function element_jacobian_at(space::ClimaCore.Spaces.AbstractSpectralElementSpac
     ξs, ws = Quadratures.quadrature_points(Float64, qs)
     Nq = length(ξs)
 
-    WJ = parent(Spaces.weighted_jacobian(space))
+    # Index the DataLayout, not parent(...): parent arrays are 5-D `(v,i,j,f,h)`.
+    WJ = Spaces.weighted_jacobian(space)
     Mξ = Quadratures.interpolation_matrix(SVector(ξ), ξs)
     Mη = Quadratures.interpolation_matrix(SVector(η), ξs)
 
     Jᵉ = 0.0
     @inbounds for q in 1:Nq, p in 1:Nq
-        Jₚᵩ = WJ[p, q, 1, elem_idx] / (ws[p] * ws[q])
+        Jₚᵩ = WJ[1, p, q, elem_idx] / (ws[p] * ws[q])
         Jᵉ += Jₚᵩ * Mξ[1, p] * Mη[1, q]
     end
     return Jᵉ
@@ -368,15 +366,9 @@ Copy values from a flat nodal vector back into a ClimaCore field.
 Inverse of [`se_field_to_vec`](@ref).
 """
 function vec_to_se_field!(field, v::AbstractVector)
-    p = parent(Fields.field_values(field))
-    Nq = size(p, 1)
-    if ndims(p) == 4
-        Nh = size(p, 4)
-        view(p, :, :, 1, :) .= reshape(v, Nq, Nq, Nh)
-    elseif ndims(p) == 5
-        Nh = size(p, 5)
-        view(p, :, :, 1, 1, :) .= reshape(v, Nq, Nq, Nh)
-    end
+    # Prefer field2array so we stay layout-agnostic across ClimaCore parent-shape
+    # changes (4-D IJFH → 5-D VIJFH in 0.15).
+    Fields.field2array(field) .= v
     return field
 end
 

--- a/test/extensions/climacore.jl
+++ b/test/extensions/climacore.jl
@@ -65,15 +65,16 @@ const ClimaCoreExt = Base.get_extension(ConservativeRegridding, :ConservativeReg
         ne = Topologies.mesh(Spaces.topology(space)).ne
 
         coords = Fields.coordinate_field(space)
-        long_data = parent(Fields.field_values(coords.long))
-        lat_data  = parent(Fields.field_values(coords.lat))
+        # ClimaCore 0.15 DataLayout indexing is (v, i, j, h); avoid parent(...).
+        long_data = Fields.field_values(coords.long)
+        lat_data  = Fields.field_values(coords.lat)
         transform = GO.UnitSphereFromGeographic()
 
         for face in 1:6
             elem_idx = (face - 1) * ne^2 + 1
             for (i, j) in ((1, 1), (Nq, Nq), (2, 3), (3, 2))
-                lon = long_data[i, j, 1, elem_idx]
-                lat = lat_data[i, j, 1, elem_idx]
+                lon = long_data[1, i, j, elem_idx]
+                lat = lat_data[1, i, j, elem_idx]
                 x = transform((lon, lat))
                 ξ, η = ClimaCoreExt.inverse_element_map(space, elem_idx, x)
                 @test ξ ≈ ξs[i] atol=1e-10
@@ -92,10 +93,10 @@ const ClimaCoreExt = Base.get_extension(ConservativeRegridding, :ConservativeReg
         ξs, ws = Quadratures.quadrature_points(Float64, qs)
         Nq = length(ξs)
 
-        WJ = parent(Spaces.weighted_jacobian(space))
+        WJ = Spaces.weighted_jacobian(space)
         elem_idx = 1
         for j in 1:Nq, i in 1:Nq
-            Jᵢⱼ = WJ[i, j, 1, elem_idx] / (ws[i] * ws[j])
+            Jᵢⱼ = WJ[1, i, j, elem_idx] / (ws[i] * ws[j])
             Jq = ClimaCoreExt.element_jacobian_at(space, elem_idx, ξs[i], ξs[j])
             @test Jq ≈ Jᵢⱼ atol=1e-10
         end


### PR DESCRIPTION
ClimaCore 0.15 unifies DataLayouts to specify a single `VIJHWithF` type to support 5 dimensional parent arrays. 