### PR TITLE
Fix threaded intersection query crashing on empty result sets

### DIFF
--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -195,9 +195,11 @@ function assemble_sparse_matrix_coo(style::S, op::O, items::I, src_tree::T1, dst
     # Fetch the results of `result_tasks`
     all_results = map(fetch, result_tasks)
     # Concatenate the per-chunk COO vectors into single vectors, in partition order.
-    rows = reduce(vcat, getindex.(all_results, 1))
-    cols = reduce(vcat, getindex.(all_results, 2))
-    vals = reduce(vcat, getindex.(all_results, 3))
+    # `init` is load-bearing: there are no partitions when `items` is empty, which is
+    # what a candidate search that found no intersecting pair returns.
+    rows = reduce(vcat, getindex.(all_results, 1); init = Int[])
+    cols = reduce(vcat, getindex.(all_results, 2); init = Int[])
+    vals = reduce(vcat, getindex.(all_results, 3); init = ValType[])
     return rows, cols, vals
 end
 # Non-threaded version

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -195,8 +195,8 @@ function assemble_sparse_matrix_coo(style::S, op::O, items::I, src_tree::T1, dst
     # Fetch the results of `result_tasks`
     all_results = map(fetch, result_tasks)
     # Concatenate the per-chunk COO vectors into single vectors, in partition order.
-    # `init` is load-bearing: there are no partitions when `items` is empty, which is
-    # what a candidate search that found no intersecting pair returns.
+    # Because we insist on integer indices anyway, we can set init to an empty vector.
+    # If the threaded search finds no candidate pairs, this prevents the dreaded `Reducing over an empty collection`
     rows = reduce(vcat, getindex.(all_results, 1); init = Int[])
     cols = reduce(vcat, getindex.(all_results, 2); init = Int[])
     vals = reduce(vcat, getindex.(all_results, 3); init = ValType[])

--- a/src/utils/MultithreadedDualDepthFirstSearch.jl
+++ b/src/utils/MultithreadedDualDepthFirstSearch.jl
@@ -61,7 +61,9 @@ function multithreaded_dual_query(
         _inner_dfs_f, predicate, parallelize1, parallelize2, tasks,
         node1, ext1, node2, ext2,
     )
-    return reduce(vcat, map(fetch, tasks))
+    # `init` is load-bearing: `tasks` is empty whenever no child pair of the two
+    # roots satisfies the predicate, i.e. the trees do not intersect at all.
+    return reduce(vcat, map(fetch, tasks); init = Tuple{Int, Int}[])
 end
 
 export multithreaded_dual_depth_first_search, multithreaded_dual_query

--- a/src/utils/MultithreadedDualDepthFirstSearch.jl
+++ b/src/utils/MultithreadedDualDepthFirstSearch.jl
@@ -61,8 +61,8 @@ function multithreaded_dual_query(
         _inner_dfs_f, predicate, parallelize1, parallelize2, tasks,
         node1, ext1, node2, ext2,
     )
-    # `init` is load-bearing: `tasks` is empty whenever no child pair of the two
-    # roots satisfies the predicate, i.e. the trees do not intersect at all.
+    # Because we insist on integer indices anyway, we can set init to an empty vector.
+    # If the threaded search finds no candidate pairs, this prevents the dreaded `Reducing over an empty collection`
     return reduce(vcat, map(fetch, tasks); init = Tuple{Int, Int}[])
 end
 

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -433,3 +433,45 @@ end
     @test size(r) == (16*16, 8*8)
     @test sum(r.intersections) > 0
 end
+
+# Two trees that share no intersecting cell pair must yield an all-zero matrix, not an
+# error. The threaded path used to hit `reduce` over an empty collection at two places,
+# one per stage, and each stage is reached with a different parallelize policy:
+#   * decline to parallelize → the dual DFS descends, no child pair passes the predicate,
+#     and it spawns no tasks at all (MultithreadedDualDepthFirstSearch);
+#   * parallelize at the root → one task runs, returns no candidate pair, and the COO
+#     assembly is then handed zero partitions (assemble_sparse_matrix_coo).
+# Both must agree with the sequential path, which has always handled this correctly.
+@testset "Threaded intersection with no intersecting pairs" begin
+    function make_grid(nx, ny; x0 = 0.0, y0 = 0.0)
+        polys = Matrix{GI.Polygon}(undef, nx, ny)
+        for j in 1:ny, i in 1:nx
+            a, b = x0 + (i-1)/nx, x0 + i/nx
+            c, d = y0 + (j-1)/ny, y0 + j/ny
+            polys[i,j] = GI.Polygon([GI.LinearRing([(a,c),(b,c),(b,d),(a,d),(a,c)])])
+        end
+        polys
+    end
+
+    # Grids must be big enough that neither root cursor is a leaf, or the dual DFS
+    # short-circuits into a task before it can come up empty.
+    src_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), make_grid(8, 8))
+    dst_tree = ConservativeRegridding.Trees.treeify(GeometryOpsCore.Planar(), make_grid(16, 16; x0 = 10.0, y0 = 10.0))
+
+    expected = ConservativeRegridding.intersection_areas(
+        GeometryOpsCore.Planar(), GeometryOpsCore.False(), dst_tree, src_tree)
+    @test nnz(expected) == 0
+
+    for parallelize in (false, true)
+        src_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+            src_tree, (tree, node, extent) -> parallelize)
+        dst_w = ConservativeRegridding.Trees.WithParallelizePolicy(
+            dst_tree, (tree, node, extent) -> parallelize)
+
+        A = ConservativeRegridding.intersection_areas(
+            GeometryOpsCore.Planar(), GeometryOpsCore.True(), dst_w, src_w)
+        @test A == expected
+        @test size(A) == size(expected)
+        @test eltype(A) == eltype(expected)
+    end
+end


### PR DESCRIPTION
## What crashes

`intersection_areas(manifold, True(), dst_tree, src_tree)` throws

```
ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
```

whenever the two trees share **no** intersecting cell pair. The sequential path (`False()`) handles exactly the same input correctly, returning an all-zero `SparseMatrixCSC` of the right size and eltype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01353CAguZrrCdbLC6iBT7Vq
