### PR TITLE
Restore vcat's O(N) specialisation in the threaded merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Breaking**: `Regridder(dst, src)` no longer promotes a `Planar`/`Spherical` mismatch to `Spherical` — any mismatch now throws, and the manifold to compute on must be passed explicitly as `Regridder(manifold, dst, src)`.
 
+### Fixed
+- The threaded intersection path no longer passes `init` to `reduce(vcat, ...)`, which bypassed `vcat`'s pre-sized specialization and made merging the per-task results quadratic in the number of tasks; emptiness is guarded explicitly instead.
+
 ## v0.2.8
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `Regridder(dst, src)` no longer promotes a `Planar`/`Spherical` mismatch to `Spherical` — any mismatch now throws, and the manifold to compute on must be passed explicitly as `Regridder(manifold, dst, src)`.
 
 ### Fixed
-- The threaded intersection path no longer passes `init` to `reduce(vcat, ...)`, which bypassed `vcat`'s pre-sized specialization and made merging the per-task results quadratic in the number of tasks; emptiness is guarded explicitly instead.
+- The threaded intersection path no longer passes `init` to `reduce(vcat, ...)`, which bypassed `vcat`'s pre-sized specialisation and made merging the per-task results quadratic in the number of tasks. Emptiness is guarded explicitly instead.
 
 ## v0.2.8
 

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -195,8 +195,7 @@ function assemble_sparse_matrix_coo(style::S, op::O, items::I, src_tree::T1, dst
     # Fetch the results of `result_tasks`
     all_results = map(fetch, result_tasks)
     # Concatenate the per-chunk COO vectors into single vectors, in partition order.
-    # Guard emptiness instead of passing `init`, which would cost `vcat`'s pre-sized
-    # specialization and make the merge quadratic in the number of partitions.
+    # `init` would cost `vcat`'s pre-sized specialisation, making this quadratic in the partition count.
     isempty(all_results) && return Int[], Int[], ValType[]
     rows = reduce(vcat, getindex.(all_results, 1))
     cols = reduce(vcat, getindex.(all_results, 2))

--- a/src/regridder/intersection_areas.jl
+++ b/src/regridder/intersection_areas.jl
@@ -195,11 +195,12 @@ function assemble_sparse_matrix_coo(style::S, op::O, items::I, src_tree::T1, dst
     # Fetch the results of `result_tasks`
     all_results = map(fetch, result_tasks)
     # Concatenate the per-chunk COO vectors into single vectors, in partition order.
-    # Because we insist on integer indices anyway, we can set init to an empty vector.
-    # If the threaded search finds no candidate pairs, this prevents the dreaded `Reducing over an empty collection`
-    rows = reduce(vcat, getindex.(all_results, 1); init = Int[])
-    cols = reduce(vcat, getindex.(all_results, 2); init = Int[])
-    vals = reduce(vcat, getindex.(all_results, 3); init = ValType[])
+    # Guard emptiness instead of passing `init`, which would cost `vcat`'s pre-sized
+    # specialization and make the merge quadratic in the number of partitions.
+    isempty(all_results) && return Int[], Int[], ValType[]
+    rows = reduce(vcat, getindex.(all_results, 1))
+    cols = reduce(vcat, getindex.(all_results, 2))
+    vals = reduce(vcat, getindex.(all_results, 3))
     return rows, cols, vals
 end
 # Non-threaded version

--- a/src/utils/MultithreadedDualDepthFirstSearch.jl
+++ b/src/utils/MultithreadedDualDepthFirstSearch.jl
@@ -61,9 +61,10 @@ function multithreaded_dual_query(
         _inner_dfs_f, predicate, parallelize1, parallelize2, tasks,
         node1, ext1, node2, ext2,
     )
-    # Because we insist on integer indices anyway, we can set init to an empty vector.
-    # If the threaded search finds no candidate pairs, this prevents the dreaded `Reducing over an empty collection`
-    return reduce(vcat, map(fetch, tasks); init = Tuple{Int, Int}[])
+    # Guard emptiness instead of passing `init`, which would cost `vcat`'s pre-sized
+    # specialization and make the merge quadratic in the number of tasks.
+    results = map(fetch, tasks)
+    return isempty(results) ? Tuple{Int, Int}[] : reduce(vcat, results)
 end
 
 export multithreaded_dual_depth_first_search, multithreaded_dual_query

--- a/src/utils/MultithreadedDualDepthFirstSearch.jl
+++ b/src/utils/MultithreadedDualDepthFirstSearch.jl
@@ -61,8 +61,7 @@ function multithreaded_dual_query(
         _inner_dfs_f, predicate, parallelize1, parallelize2, tasks,
         node1, ext1, node2, ext2,
     )
-    # Guard emptiness instead of passing `init`, which would cost `vcat`'s pre-sized
-    # specialization and make the merge quadratic in the number of tasks.
+    # `init` would cost `vcat`'s pre-sized specialisation, making this quadratic in the task count.
     results = map(fetch, tasks)
     return isempty(results) ? Tuple{Int, Int}[] : reduce(vcat, results)
 end


### PR DESCRIPTION
#132 fixed a real crash — `reduce(vcat, x)` throws `ArgumentError: reducing over an empty collection is not allowed` when the threaded search finds no candidate pairs — but it fixed it with `init =`, which makes the merge quadratic.

`reduce(vcat, ::AbstractVector{<:AbstractVecOrMat})` has an O(N) specialisation in `Base` (`abstractarray.jl`, `_typed_vcat`): it allocates the output once at the total size and copies each part in exactly once. Passing *any* `init` bypasses that method and falls back to `mapfoldl`, i.e. a left fold that re-copies the whole accumulator once per element — O(N · ntasks) time and allocation.

This restores the specialisation and keeps the empty-collection safety by guarding on emptiness instead. Four sites: the dual-query merge in `MultithreadedDualDepthFirstSearch`, and the three COO merges in `assemble_sparse_matrix_coo` (guarded once on `all_results`). Note `map(fetch, tasks)` over empty `tasks` is not `Vector{Tuple{Int,Int}}`, so the guard has to sit outside the `reduce`.

The regression test #132 added ("Threaded intersection with no intersecting pairs", `test/regridding.jl`) is unchanged and still passes.

## Measurements

All on Julia 1.12.6, 8 threads, minimum over repeats.

Microbenchmark of the merge alone, at the shape the threaded search produces (20 736 tasks × 7 pairs):

| form | time | alloc |
|---|---|---|
| `reduce(vcat, x; init = T[])` | 10 420 ms | 22 966 MiB |
| `isempty(x) ? T[] : reduce(vcat, x)` | 0.542 ms | 2.37 MiB |

Same measurement on the task vector the package's own dual query actually produces, for two planar `RegularGrid` pairs built through `Trees.treeify`:

| src cells | tasks | pairs | with `init` | guarded |
|---|---|---|---|---|
| 18 432 | 3 732 | 113 764 | 1 102 ms / 3 244 MiB | 0.281 ms / 1.76 MiB |
| 73 728 | 2 116 | 457 924 | 2 836 ms / 7 396 MiB | 0.596 ms / 7.00 MiB |

End to end, `Regridder(Planar(), dst, src; threaded = true)` on the same grids:

| src → dst cells | before | after |
|---|---|---|
| 18 432 → 28 800 | 2.18 s / 3.56 GiB | 0.14 s / 0.37 GiB |
| 73 728 → 115 200 | 5.65 s / 8.80 GiB | 0.43 s / 1.48 GiB |

The allocation deltas match the phase-split numbers, so essentially all of the removed cost is the merge.

On a real IGEO7-level-13 × Copernicus-GLO-30 regrid (82 944 source cells) the same defect made the threaded path slower than serial: 1 thread 38.9 s / 7.4 GiB, 8 threads 52.5 s / 385 GiB, 64 threads 62.3 s / 387 GiB. That workload is not reproducible from this repo, so it is quoted for context only; the numbers above are the ones measured here.

## Tests

`julia --project=test -t 8 test/runtests.jl` on this branch:

```
Test Summary:             |  Pass  Total      Time
ConservativeRegridding.jl | 10029  10029  13m15.2s
```

(One environment note, unrelated to this change: `Pkg.instantiate()` in `test/` fails because ClimaCore's dependency GilbertCurves resolves to `https://github.com/CliMA/GilbertCurves.jl.git`, which now 404s; the package is still served by the Julia package server, so installing it from there unblocks the environment.)

## Known issue, not fixed here

`src/utils/MultithreadedDualDepthFirstSearch.jl:19-21` spawns a task unconditionally in the `isleaf` branch, bypassing `should_parallelize` entirely, so it spawns roughly one task per source cell rather than the number the tree's own policy asks for. That inflates `ntasks`, which is what the quadratic merge was multiplied by. It is a separate change with different risk and is left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYsLTQDR6sHuQGeHakPBT7
