### PR TITLE
Spawn a dual-DFS task once either tree reaches its parallelize granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `Regridder(dst, src)` no longer promotes a `Planar`/`Spherical` mismatch to `Spherical` — any mismatch now throws, and the manifold to compute on must be passed explicitly as `Regridder(manifold, dst, src)`.
 
 ### Fixed
+- The threaded dual-tree walk now spawns a task as soon as *either* tree's `should_parallelize` fires rather than requiring both, so a tree whose policy fires late no longer forces the other tree to be split down to its leaves.
 - The threaded intersection path no longer passes `init` to `reduce(vcat, ...)`, which bypassed `vcat`'s pre-sized specialisation and made merging the per-task results quadratic in the number of tasks. Emptiness is guarded explicitly instead.
 
 ## v0.2.8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ The manifold affects extent computation, intersection algorithms, and area calcu
 
 ### Multithreading
 
-`multithreaded_dual_query` (`src/utils/MultithreadedDualDepthFirstSearch.jl`): Parallel dual-tree traversal. Spawns tasks when both nodes are leaves or when nodes satisfy an area criterion (avoids spawning excessive tasks for small regions). Intersection area computation is separately parallelized via ChunkSplitters partitioning.
+`multithreaded_dual_query` (`src/utils/MultithreadedDualDepthFirstSearch.jl`): Parallel dual-tree traversal. Spawns a task when either node is a leaf or either node's `should_parallelize` fires (avoids spawning excessive tasks for small regions). Intersection area computation is separately parallelized via ChunkSplitters partitioning.
 
 ### Package Extensions (`ext/`)
 

--- a/src/trees/interfaces.jl
+++ b/src/trees/interfaces.jl
@@ -31,6 +31,10 @@ purpose of further parallelism and runs the subtree as a single parallel
 unit. Returning `false` means *keep descending* — the node is still too
 coarse and a task at this level would create unbalanced work.
 
+The dual walk spawns as soon as *either* tree's policy fires, since one side
+reaching its granularity already bounds the pair's work; a policy that fires
+early therefore caps the task count for both trees.
+
 `extent` is the bounding region of `node` (e.g. an `Extents.Extent` for
 planar grids or a `SphericalCap` for spherical grids). It is passed
 explicitly so implementations and the dual DFS share one computation per

--- a/src/utils/MultithreadedDualDepthFirstSearch.jl
+++ b/src/utils/MultithreadedDualDepthFirstSearch.jl
@@ -5,10 +5,11 @@ using GeometryOps.LoopStateMachine: @controlflow
 import ProgressMeter
 import StableTasks
 
-# Walk through both trees and kick off a task whenever both nodes' parallelize
-# predicates fire. Each parallelize_k closure is `(node, extent) -> Bool` and is
-# pre-bound to its tree by the caller. Extents are computed exactly once per
-# node and threaded through the recursion.
+# Walk through both trees and kick off a task as soon as either node's parallelize
+# predicate fires, since one side reaching its granularity already bounds the pair's
+# work. Each parallelize_k closure is `(node, extent) -> Bool` and is pre-bound to its
+# tree by the caller. Extents are computed exactly once per node and threaded through
+# the recursion.
 function multithreaded_dual_depth_first_search(
     inner_dfs_f::IF, predicate::P,
     parallelize1::A1, parallelize2::A2,
@@ -21,7 +22,7 @@ function multithreaded_dual_depth_first_search(
         push!(tasks, StableTasks.@spawn $inner_dfs_f($predicate, node1, node2))
     else
         # neither node is a leaf, recurse into both children
-        if parallelize1(node1, ext1) && parallelize2(node2, ext2)
+        if parallelize1(node1, ext1) || parallelize2(node2, ext2)
             push!(tasks, StableTasks.@spawn $inner_dfs_f($predicate, node1, node2))
         else
             for child1 in STI.getchild(node1)

--- a/test/regridding.jl
+++ b/test/regridding.jl
@@ -5,6 +5,9 @@ import GeometryOps as GO, GeoInterface as GI
 import GeometryOpsCore
 import Extents
 using SparseArrays
+using GeometryOps: SpatialTreeInterface as STI
+const MDDFS = ConservativeRegridding.MultithreadedDualDepthFirstSearch
+const StableTasks = ConservativeRegridding.StableTasks
 
 @testset "Custom intersection_operator" begin
     make_square() = GI.Polygon([GI.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)])])
@@ -474,4 +477,46 @@ end
         @test size(A) == size(expected)
         @test eltype(A) == eltype(expected)
     end
+end
+
+# Follow-up to #133: the dual walk used to require *both* policies before spawning, so a
+# destination policy that never fires forced the source to be split all the way down to
+# its leaves — one task per source leaf, however many that is.
+@testset "Dual DFS stops at the first tree to reach granularity" begin
+    src_tree = ConservativeRegridding.Trees.treeify(
+        ConservativeRegridding.RegularGrid(range(0, 1; length = 17), range(0, 1; length = 17)))
+    dst_tree = ConservativeRegridding.Trees.treeify(
+        ConservativeRegridding.RegularGrid(range(0, 1; length = 129), range(0, 1; length = 129)))
+
+    par_src = (node, extent) -> prod(ConservativeRegridding.Trees.ncells(node)) <= 16
+    par_dst = (node, extent) -> false
+
+    # Record the source node each task is spawned on, then run the real inner search.
+    spawned_on = Int[]
+    spawn_lock = ReentrantLock()
+    inner = function (predicate, node1, node2)
+        n = prod(ConservativeRegridding.Trees.ncells(node1))
+        lock(spawn_lock) do; push!(spawned_on, n); end
+        return MDDFS._inner_dfs_f(predicate, node1, node2)
+    end
+
+    tasks = StableTasks.StableTask{Vector{Tuple{Int, Int}}}[]
+    MDDFS.multithreaded_dual_depth_first_search(
+        inner, Extents.intersects, par_src, par_dst, tasks,
+        src_tree, STI.node_extent(src_tree), dst_tree, STI.node_extent(dst_tree),
+    )
+    threaded_pairs = reduce(vcat, map(fetch, tasks))
+
+    @test length(spawned_on) == length(tasks)
+    # Every task sits on a 4x4 source block - the granularity `par_src` asked for - not
+    # on a 2x2 source leaf.
+    @test all(==(16), spawned_on)
+
+    serial_pairs = Tuple{Int, Int}[]
+    STI.dual_depth_first_search(Extents.intersects, src_tree, dst_tree) do i1, i2
+        push!(serial_pairs, (i1, i2))
+    end
+    # Spawning earlier only cuts the same walk higher up, so the pairs match exactly,
+    # in order.
+    @test threaded_pairs == serial_pairs
 end


### PR DESCRIPTION
Follow-up to #133.

## The problem

`multithreaded_dual_depth_first_search` spawned a task only when **both**
`should_parallelize` predicates fired:

```julia
if parallelize1(node1, ext1) && parallelize2(node2, ext2)
```

`Trees.should_parallelize` returning `true` means *this node is the granularity at which
a task is spawned* — but under the conjunction a `true` on one side did nothing until the
other side agreed. So when the two trees reach their granularities at different depths
(the usual case when a quadtree cursor is paired with a hierarchical DGGS cursor, whose
stored-cell count barely drops for the first several levels of a regional window), the
walk kept splitting the tree that was already fine enough, all the way down to its
leaves — at which point the `isleaf` branch above spawned unconditionally, one task per
leaf pair.

Measured on a Copernicus GLO-30 window regridded onto `DiscreteGlobalGrids`' IGEO7
level 13 (`bucket_size = 0`, so `HierarchicalGridCursor` leaves hold one cell each), at
8 threads, where the policy asks for `nthreads * 32 = 256` tasks:

| source cells | destination cells | tasks on `main` |
|---:|---:|---:|
| 5 184 | 7 107 | 2 368 |
| 20 736 | 27 262 | 18 944 |

## The fix

`&&` → `||`. One side reaching its granularity already bounds the pair's work — a node
covering ≤ 1/K of its own tree can only be involved in ≤ 1/K of the candidate pairs,
whatever the opposing node is — so there is nothing to gain by splitting past it.

## Results are unchanged, order included

Spawning earlier only cuts the *same* recursion tree higher up: the branch structure of
the walk is untouched, every task still runs the ordinary serial `dual_depth_first_search`
on its node pair, and the tasks are concatenated in spawn order. So the candidate-pair
list is identical — **as a list, not merely as a set**.

Verified rather than assumed:

- 20 429 232 pairs across twelve planar `RegularGrid` pairs (2×2 through 1024×1024, both
  square and lopsided) serialised on `main` and on this branch: every vector identical
  element-for-element.
- The GLO-30 → IGEO7 case at 1, 8 and 64 threads: threaded pairs `==` serial pairs on
  both branches (`order_eq = true`), 185 600 pairs.
- End-to-end `intersection_areas` over six planar cases: identical `nnz` and identical
  `sum(nzval)`.

Because the list is identical, `work_items`, the `assemble_sparse_matrix_coo` partitioning
and `sparse()`'s duplicate summation all see exactly what they saw before; no
order-independence argument is needed.

The empty-result guards from #132/#133 are unaffected — the "no intersecting pairs"
testset exercises `parallelize = false` (walk descends, spawns nothing) and
`parallelize = true` (one task at the root, no pairs) and both still take those paths.
The serial `::False` path is untouched.

## Measurements

Copernicus GLO-30 window → IGEO7 level 13, candidate-pair query only, best of 5, idle
machine:

| threads | source cells | tasks before | tasks after | ms before | ms after |
|---:|---:|---:|---:|---:|---:|
| 1 | 5 184 | 2 368 | 64 | 1 321 | 1 265 |
| 1 | 20 736 | 18 944 | 64 | 6 947 | 4 243 |
| 8 | 5 184 | 2 368 | 448 | 273 | 237 |
| 8 | 20 736 | 18 944 | 256 | 3 375 | 686 |
| 64 | 5 184 | 2 368 | 2 368 | 206 | 204 |
| 64 | 20 736 | 18 944 | 8 192 | 3 563 | 1 299 |

Two planar `RegularGrid`s through `Trees.treeify` (#133's shape). Both trees are
`TopDownQuadtreeCursor`s, so both policies fire at the same depth and the two branches
are mostly identical by construction; the one case that differs is the one where the
source is small enough that its threshold floors out:

| threads | case | tasks before | tasks after | ms before | ms after |
|---:|---|---:|---:|---:|---:|
| 8 | 72² → 144² | 2 436 | 1 444 | 3.7 | 2.3 |
| 8 | 1024² → 1024² | 2 116 | 2 116 | 280 | 318 |
| 64 | 256² → 256² | 36 100 | 36 100 | 373 | 325 |

Everything else in that sweep is unchanged in task count and within noise in time.

## Alternatives measured and rejected

The `isleaf` branch still spawns unconditionally, so a tree that *is* a single leaf, or
that bottoms out before either policy fires, still yields one task for whatever it is
paired against (e.g. a 2×2 source against a 1024×1024 destination: one task, 1 M pairs).
Two fixes for that were implemented and measured:

1. **Descend the non-leaf side with the leaf held fixed, at any node.** Fixes the above
   (87 ms → 14 ms at 8 threads) and cuts the GLO-30 case to 2 801 tasks — but it is
   wrong: it tests an opposing child against a *parent* extent, and the trees' bounding
   caps are not nested. Checking every parent/child pair in the GLO-30 case, 2 432 of
   3 156 source-cursor children and 211 of 8 398 destination-cursor children have caps
   escaping their parent's by up to 2.4e-6 rad. The result was 55 lost candidate pairs
   out of 148 102. Rejected on correctness.
2. **The same, restricted to genuine leaves** (so the branch structure still mirrors the
   serial walk, and results stay identical). Correct, but it makes the GLO-30 case *worse*:
   30 722 tasks and 7 466 ms against 18 944 / 2 973 ms on `main`, because the destination
   policy fires so late that each source leaf drags the destination down several more
   levels. Rejected on measurement.

So the leaf branch is left alone, and one line changes.

## Regression test

`test/regridding.jl` gains a testset that drives `multithreaded_dual_depth_first_search`
directly with a source policy that fires at 4×4 blocks and a destination policy that
never fires, wraps the inner search to record the source node each task lands on, and
asserts every task sits on a 4×4 block rather than a 2×2 leaf — plus that the threaded
pairs equal the serial pairs exactly, in order. No timing involved.

## Test suite

Full `test/runtests.jl`, `-t 8`, run in groups so each fits the sandbox's foreground
limit; every testset in `runtests.jl` is covered (`SpeedyWeather` is commented out on
`main`).

```
group1 (TriangleQuadrature, Regridding, Grids, QuadtreeCursors) | 1451  1451   19.3s
group2 (Oceananigans, ClimaCore, Healpix, RingGrids x2, NCDatasets) | 6603  6603  2m33.6s
group3 (XESMF comparison)                                       |   16    16   55.8s
group4 (simple, oceananigans, climacore, constant_field, fullclenshaw) |  115   115  2m22.9s
group5 (sweat, vector path)                                     |  994   994  5m16.7s
group6 (sweat_field, field path)                                |  853   853  7m25.0s
```

10 032 tests, 0 failures, 0 errors.

## Notes

- `CHANGELOG.md` gains one line under `## Unreleased` → `### Fixed`. No version bump: #133
  and the other entries in that section are unreleased too, and the repo bumps at release
  time, not per PR.
- One behavioural note for tree authors, added to the `should_parallelize` docstring: a
  policy that fires early now caps the task count for *both* trees. The
  `should_parallelize(::Any, ::SphericalCap)` fallback ("spawn once the cap covers less
  than ¼ of the sphere") fires at the root for any regional tree, so a foreign tree
  relying on that fallback and paired with a global grid will now spawn at the root. That
  fallback already produced one task for regional × regional pairings; trees that care
  should supply a real policy or `WithParallelizePolicy`, which is what the docstring
  already recommends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYsLTQDR6sHuQGeHakPBT7
